### PR TITLE
[MMCA-4482] - Implement language toggle on the statement request confirmation pages

### DIFF
--- a/app/controllers/ConfirmationPageController.scala
+++ b/app/controllers/ConfirmationPageController.scala
@@ -55,19 +55,22 @@ class ConfirmationPageController @Inject()(
           case Left(_) => None
         }.recover { case _ => None }
 
-      } yield Ok(view(email, fileRole, returnLink, dates.dateRows(fileRole).getOrElse(emptyString)))
+      } yield Ok(
+        view(email,
+          fileRole,
+          returnLink,
+          dates.dateRows(fileRole).getOrElse(emptyString))
+      )
   }
 
   def returnToStatementsPage(fileRole: FileRole): Action[AnyContent] = {
     (identify andThen getData andThen requireData).async {
-
       implicit request =>
-        val returnLink = appConfig.returnLink(fileRole, request.userAnswers)
 
         for {
           _ <- sessionRepository.clear(request.internalId).recover { case _ => true }
         } yield {
-          Redirect(returnLink)
+          Redirect(appConfig.returnLink(fileRole, request.userAnswers))
         }
     }
   }

--- a/app/controllers/ConfirmationPageController.scala
+++ b/app/controllers/ConfirmationPageController.scala
@@ -24,8 +24,9 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import views.html.ConfirmationPageView
+import utils.Utils.emptyString
 import viewmodels.CheckYourAnswersHelper
+import views.html.ConfirmationPageView
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
@@ -39,18 +40,36 @@ class ConfirmationPageController @Inject()(
                                             customsDataStoreConnector: CustomsDataStoreConnector,
                                             val controllerComponents: MessagesControllerComponents,
                                             view: ConfirmationPageView
-                                          )(implicit ec: ExecutionContext, appConfig: FrontendAppConfig) extends FrontendBaseController with I18nSupport {
+                                          )(implicit ec: ExecutionContext, appConfig: FrontendAppConfig)
+  extends FrontendBaseController with I18nSupport {
 
   def onPageLoad(fileRole: FileRole): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
+
       val dates = new CheckYourAnswersHelper(request.userAnswers)
+      val returnLink = routes.ConfirmationPageController.returnToStatementsPage(fileRole).url
+
       for {
         email <- customsDataStoreConnector.getEmail(request.eori).map {
           case Right(email) => Some(email)
           case Left(_) => None
         }.recover { case _ => None }
-        _ <- sessionRepository.clear(request.internalId)
-        returnLink = appConfig.returnLink(fileRole, request.userAnswers)
-      } yield Ok(view(email, fileRole, returnLink, dates.dateRows(fileRole).getOrElse("")))
+
+      } yield Ok(view(email, fileRole, returnLink, dates.dateRows(fileRole).getOrElse(emptyString)))
+  }
+
+  def returnToStatementsPage(fileRole: FileRole): Action[AnyContent] = {
+    (identify andThen getData andThen requireData).async {
+
+      implicit request =>
+        val returnLink = appConfig.returnLink(fileRole, request.userAnswers)
+
+        for {
+          _ <- sessionRepository.clear(request.internalId).recover { case _ => true }
+        } yield {
+          Redirect(returnLink)
+        }
     }
   }
+
+}

--- a/app/controllers/LogoutController.scala
+++ b/app/controllers/LogoutController.scala
@@ -17,21 +17,40 @@
 package controllers
 
 import config.FrontendAppConfig
+import controllers.actions.IdentifierAction
 import play.api.mvc._
+import repositories.SessionRepository
 import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisedFunctions}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.Inject
+import scala.concurrent.ExecutionContext
 
-class LogoutController @Inject()(override val authConnector: AuthConnector, mcc: MessagesControllerComponents)
-                                (implicit val appConfig: FrontendAppConfig)
+class LogoutController @Inject()(override val authConnector: AuthConnector,
+                                 authenticate: IdentifierAction,
+                                 sessionRepository: SessionRepository,
+                                 mcc: MessagesControllerComponents)
+                                (implicit val appConfig: FrontendAppConfig, ec: ExecutionContext)
   extends FrontendController(mcc) with AuthorisedFunctions {
 
-  def logout: Action[AnyContent] = Action {
-    Redirect(appConfig.signOutUrl, Map("continue" -> Seq(appConfig.feedbackService)))
+  def logout: Action[AnyContent] = authenticate.async {
+    implicit request =>
+
+      for {
+        _ <- sessionRepository.clear(request.identifier).recover { case _ => true }
+      } yield {
+        Redirect(appConfig.signOutUrl, Map("continue" -> Seq(appConfig.feedbackService)))
+      }
+
   }
 
-  def logoutNoSurvey: Action[AnyContent] = Action {
-    Results.Redirect(appConfig.signOutUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
+  def logoutNoSurvey: Action[AnyContent] = authenticate.async {
+    implicit request =>
+
+      for {
+        _ <- sessionRepository.clear(request.identifier).recover { case _ => true }
+      } yield {
+        Results.Redirect(appConfig.signOutUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
+      }
   }
 }

--- a/app/utils/Utils.scala
+++ b/app/utils/Utils.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+object Utils {
+  val emptyString = ""
+}

--- a/app/views/ConfirmationPageView.scala.html
+++ b/app/views/ConfirmationPageView.scala.html
@@ -38,8 +38,7 @@
 
 @layout(
     pageTitle = Some(messages("cf.accounts.title")),
-    dutyDeferment = fileRole == DutyDefermentStatement,
-    welshToggle = false
+    dutyDeferment = fileRole == DutyDefermentStatement
     ) {
 
     <div class="govuk-panel govuk-panel--confirmation">
@@ -72,5 +71,7 @@
         content = Html(messages(s"cf.historic.document.request.confirmation.body-text2.${fileRole.name}"))
     )
 
-    @p(link(messages(s"cf.historic.document.request.confirmation.${fileRole.name}.link-text"), location = returnLink))
+    @p(link(linkMessage = messages(s"cf.historic.document.request.confirmation.${fileRole.name}.link-text"),
+            location = returnLink)
+    )
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -25,6 +25,7 @@ GET         /:fileRole/selected-statements               controllers.CheckYourAn
 POST        /:fileRole/selected-statements               controllers.CheckYourAnswersController.onSubmit(fileRole: FileRole)
 
 GET         /:fileRole/confirmation                      controllers.ConfirmationPageController.onPageLoad(fileRole: FileRole)
+GET         /:fileRole/confirmation/return-to-statements controllers.ConfirmationPageController.returnToStatementsPage(fileRole: FileRole)
 
 GET         /requested/:fileRole                         controllers.HistoricStatementsController.historicStatements(fileRole: FileRole)
 GET         /requested/duty-deferment/:linkId            controllers.HistoricStatementsController.historicStatementsDutyDeferment(linkId: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -79,7 +79,7 @@ microservice {
       }
 
       feedback {
-        url = "https://www.development.tax.service.gov.uk/feedback"
+        url = "http://localhost:9514/feedback"
         source = "/CDS-FIN"
       }
     }

--- a/test/config/FrontendAppConfigSpec.scala
+++ b/test/config/FrontendAppConfigSpec.scala
@@ -20,52 +20,50 @@ import base.SpecBase
 import models.{C79Certificate, DutyDefermentStatement, SecurityStatement}
 import org.scalatest.TryValues.convertTryToSuccessOrFailure
 import pages.RequestedLinkId
-import play.api.test.Helpers.running
+import play.api.Application
 
 class FrontendAppConfigSpec extends SpecBase {
 
   "returnLink" should {
     "return the adjustments link if a SecurityStatement FileRole provided" in new Setup {
-      running(app){
-        config.returnLink(SecurityStatement, emptyUserAnswers) mustBe "http://localhost:9398/customs/documents/adjustments"
-      }
+      config.returnLink(SecurityStatement, emptyUserAnswers) mustBe
+        "http://localhost:9398/customs/documents/adjustments"
     }
-    
 
     "return the adjustments link if a C79Certificate FileRole provided" in new Setup {
-      running(app) {
-        config.returnLink(C79Certificate, emptyUserAnswers) mustBe "http://localhost:9398/customs/documents/import-vat"
-      }
+      config.returnLink(C79Certificate, emptyUserAnswers) mustBe
+        "http://localhost:9398/customs/documents/import-vat"
     }
 
     "return the DutyDeferment link if a DutyDeferment FileRole provided and linkId in user answers" in new Setup {
-      
-      running(app) {
-        config.returnLink(
-          DutyDefermentStatement,
-          emptyUserAnswers.set(RequestedLinkId, "someLink").success.value) mustBe "http://localhost:9397/customs/duty-deferment/someLink/account"
-      }
+      config.returnLink(
+        DutyDefermentStatement,
+        emptyUserAnswers.set(RequestedLinkId, "someLink").success.value) mustBe
+        "http://localhost:9397/customs/duty-deferment/someLink/account"
     }
 
     "throw an exception if DutyDeferment FileRole and no linkId in user answers" in new Setup {
-      running(app) {
-        intercept[Exception] {
-          config.returnLink(DutyDefermentStatement, emptyUserAnswers) mustBe "http://localhost:9398/customs/documents/import-vat"
-        }.getMessage mustBe "Unable to retrieve linkId"
-      }
+      intercept[Exception] {
+        config.returnLink(DutyDefermentStatement, emptyUserAnswers) mustBe
+          "http://localhost:9398/customs/documents/import-vat"
+      }.getMessage mustBe "Unable to retrieve linkId"
     }
 
     "throw an exception if DutyDeferment fileRole is passed " in new Setup {
-      running(app) {
-        intercept[Exception] {
-          config.returnLink(DutyDefermentStatement) mustBe "http://localhost:9398/customs/documents/import-vat"
-        }.getMessage mustBe "Invalid file role"
-      }
+      intercept[Exception] {
+        config.returnLink(DutyDefermentStatement) mustBe "http://localhost:9398/customs/documents/import-vat"
+      }.getMessage mustBe "Invalid file role"
+    }
+  }
+
+  "feedbackService" should {
+    "return correct url" in new Setup {
+      config.feedbackService mustBe "http://localhost:9514/feedback/CDS-FIN"
     }
   }
 
   trait Setup {
-    val app = applicationBuilder().build()
-    val config = app.injector.instanceOf[FrontendAppConfig]
+    val app: Application = applicationBuilder().build()
+    val config: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
   }
 }

--- a/test/controllers/LogoutControllerSpec.scala
+++ b/test/controllers/LogoutControllerSpec.scala
@@ -17,39 +17,99 @@
 package controllers
 
 import base.SpecBase
-import play.api.Application
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import play.api.{Application, inject}
+import repositories.SessionRepository
+
+import scala.concurrent.Future
 
 class LogoutControllerSpec extends SpecBase {
 
   "logout" should {
-    "redirect the user to logout with a continue url of the feedback survey" in new Setup {
-      val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest(GET, routes.LogoutController.logout.url)
-      running(app) {
-        val result = route(app, request).value
-        status(result) mustBe SEE_OTHER
-        redirectLocation(result).value mustBe "http://localhost:9553/bas-gateway/sign-out-without-state?continue=https%3A%2F%2Fwww.development.tax.service.gov.uk%2Ffeedback%2FCDS-FIN"
+
+    "redirect the user to logout with a continue url of the feedback survey" when {
+
+      "sessionRepository clears the user session successfully" in new Setup {
+        val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest(GET, routes.LogoutController.logout.url)
+
+        when(sessionRepoMock.clear(any)).thenReturn(Future.successful(true))
+
+        running(app) {
+          val result = route(app, request).value
+
+          status(result) mustBe SEE_OTHER
+
+          redirectLocation(result).value mustBe
+            "http://localhost:9553/bas-gateway/sign-out-without-state?" +
+              "continue=http%3A%2F%2Flocalhost%3A9514%2Ffeedback%2FCDS-FIN"
+        }
       }
+
+      "error occurs in clearing user session" in new Setup {
+        val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest(GET, routes.LogoutController.logout.url)
+
+        when(sessionRepoMock.clear(any)).thenReturn(Future.failed(new RuntimeException("error occurred")))
+
+        running(app) {
+          val result = route(app, request).value
+
+          status(result) mustBe SEE_OTHER
+
+          redirectLocation(result).value mustBe
+            "http://localhost:9553/bas-gateway/sign-out-without-state?" +
+              "continue=http%3A%2F%2Flocalhost%3A9514%2Ffeedback%2FCDS-FIN"
+        }
+      }
+
     }
   }
 
   "logoutNoSurvey" should {
-    "redirect the user to logout with no feedback survey continueUrl" in new Setup {
-      val request = fakeRequest(GET, routes.LogoutController.logoutNoSurvey.url)
-      running(app) {
-        val result = route(app, request).value
-        status(result) mustBe SEE_OTHER
-        redirectLocation(result).value mustBe "http://localhost:9553/bas-gateway/sign-out-without-state?continue=http%3A%2F%2Flocalhost%3A9876%2Fcustoms%2Fpayment-records"
+
+    "redirect the user to logout with no feedback survey continueUrl" when {
+
+      "sessionRepository clears the user session successfully" in new Setup {
+        val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest(GET, routes.LogoutController.logoutNoSurvey.url)
+
+        when(sessionRepoMock.clear(any)).thenReturn(Future.successful(true))
+
+        running(app) {
+          val result = route(app, request).value
+
+          status(result) mustBe SEE_OTHER
+
+          redirectLocation(result).value mustBe
+            "http://localhost:9553/bas-gateway/sign-out-without-state?" +
+              "continue=http%3A%2F%2Flocalhost%3A9876%2Fcustoms%2Fpayment-records"
+        }
+      }
+
+      "error occurs in clearing user session" in new Setup {
+        val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest(GET, routes.LogoutController.logoutNoSurvey.url)
+
+        when(sessionRepoMock.clear(any)).thenReturn(Future.failed(new RuntimeException("error occurred")))
+
+        running(app) {
+          val result = route(app, request).value
+
+          status(result) mustBe SEE_OTHER
+
+          redirectLocation(result).value mustBe
+            "http://localhost:9553/bas-gateway/sign-out-without-state?" +
+              "continue=http%3A%2F%2Flocalhost%3A9876%2Fcustoms%2Fpayment-records"
+        }
       }
     }
-  }
 
+  }
 
   trait Setup {
-    val app: Application = applicationBuilder().build()
+    val sessionRepoMock: SessionRepository = mock[SessionRepository]
+
+    val app: Application = applicationBuilder().overrides(
+      inject.bind[SessionRepository].toInstance(sessionRepoMock)
+    ).build()
   }
-
-
 }

--- a/test/utils/UtilsSpec.scala
+++ b/test/utils/UtilsSpec.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import base.SpecBase
+import utils.Utils.emptyString
+
+class UtilsSpec extends SpecBase {
+  "emptyString" should {
+
+    "return correct value" in {
+      emptyString mustBe ""
+    }
+  }
+}

--- a/test/views/ConfirmationPageViewSpec.scala
+++ b/test/views/ConfirmationPageViewSpec.scala
@@ -33,45 +33,49 @@ import views.html.ConfirmationPageView
 class ConfirmationPageViewSpec extends SpecBase {
 
   "view" should {
+
     "display correct text" when {
+
       "title should display correctly" in new Setup {
-        running(app) {
-          view.title() mustBe s"${messages(app)(
-            "cf.accounts.title")} - ${messages(app)("service.name")} - GOV.UK"
-        }
+        view.title() mustBe s"${
+          messages(app)(
+            "cf.accounts.title")
+        } - ${messages(app)("service.name")} - GOV.UK"
       }
 
       "date should display correctly" in new Setup {
-        running(app) {
-          view.getElementById(
-            "email-confirmation-panel-date").text() mustBe messages(app)(
-            "03 Oct 2021 to 04 Sept 2022")
-        }
+        view.getElementById(
+          "email-confirmation-panel-date").text() mustBe messages(app)(
+          "03 Oct 2021 to 04 Sept 2022")
       }
 
       "subheader-text should display correctly" in new Setup {
-        running(app) {
-          view.getElementById(
-            "email-confirmation-subheader").text() mustBe messages(app)(
-            "cf.historic.document.request.confirmation.subheader-text.next")
-        }
+        view.getElementById(
+          "email-confirmation-subheader").text() mustBe messages(app)(
+          "cf.historic.document.request.confirmation.subheader-text.next")
       }
 
       "email confirmation should display correctly" in new Setup {
-        running(app) {
-            view.getElementById(
-              "email-confirmation").text() mustBe messages(app)(
-              "cf.historic.document.request.confirmation.body-text.request", email.value)
-          }
+        view.getElementById(
+          "email-confirmation").text() mustBe messages(app)(
+          "cf.historic.document.request.confirmation.body-text.request", email.value)
       }
-      
+
       "body-text2 should display correctly" in new Setup {
-        running(app) {
-          view.getElementById(
-            "body-text2").text() mustBe messages(app)(
-            s"cf.historic.document.request.confirmation.body-text2.${fileRole.name}")
-        }
+        view.getElementById(
+          "body-text2").text() mustBe messages(app)(
+          s"cf.historic.document.request.confirmation.body-text2.${fileRole.name}")
       }
+    }
+
+    "display Welsh toggle" in new Setup {
+      val languageSelectHtml: Document =
+        Jsoup.parse(view.getElementsByClass("hmrc-language-select__list-item").html())
+
+      val welshLinkElement: String = languageSelectHtml.getElementsByTag("a").html()
+
+      languageSelectHtml.toString.contains("English") mustBe true
+      welshLinkElement.contains("Cymraeg") mustBe true
     }
   }
 


### PR DESCRIPTION
Description - Code changes to enable language toggle

Below has been done as part of this PR

- add tests and relevant code changes
- add Utils object and class test
- remove user session on return link and logout link
- update feedback service link for local env as it was failing with incorrect url (of dev env)
- minor refactoring