### PR TITLE
MMCA-4812 | Moved complex logic from the View to the ViewModel

### DIFF
--- a/app/controllers/HistoricStatementsController.scala
+++ b/app/controllers/HistoricStatementsController.scala
@@ -25,7 +25,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import services.SortStatementsService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import viewmodels.{DutyDefermentAccountViewModel, PostponedVatViewModel, VatViewModel}
+import viewmodels.{DutyDefermentAccountViewModel, PostponedVatViewModel, SecuritiesRequestedStatementsViewModel, VatViewModel}
 import views.html._
 
 import javax.inject.Inject
@@ -105,7 +105,10 @@ class HistoricStatementsController @Inject()(identify: IdentifierAction,
             .getSecurityStatements(historicEori.eori)
             .map(sortStatementsService.sortSecurityCertificatesForEori(historicEori, _))
       })
-    } yield Ok(securitiesView(allCertificates, appConfig.returnLink(SecurityStatement)))
+    } yield {
+      val model = SecuritiesRequestedStatementsViewModel(allCertificates)
+      Ok(securitiesView(model, appConfig.returnLink(SecurityStatement)))
+    }
   }
 
   private def showHistoricDutyDefermentStatements(dan: String, linkId: String)(

--- a/app/utils/Utils.scala
+++ b/app/utils/Utils.scala
@@ -16,8 +16,16 @@
 
 package utils
 
+import views.html.components.{h2, missing_documents_guidance, p, span, span_link}
+
 object Utils {
   val emptyString = ""
   val comma = ","
   val hyphen = "-"
+
+  val h2Component = new h2()
+  val pComponent = new p()
+  val spanComponent = new span()
+  val spanLinkComponent = new span_link()
+  val missingDocumentsGuidanceComponent = new missing_documents_guidance(h2Component, pComponent)
 }

--- a/app/viewmodels/SecuritiesRequestedStatementsViewModel.scala
+++ b/app/viewmodels/SecuritiesRequestedStatementsViewModel.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels
+
+import helpers.Formatters.dateAsDayMonthAndYear
+import models.FileFormat.Pdf
+import models.SecurityStatementsForEori
+import play.api.i18n.Messages
+import play.twirl.api.{Html, HtmlFormat}
+
+case class StatementRow(historyIndex: Int,
+                        eori: Option[String],
+                        date: String,
+                        pdf: Option[PdfLink],
+                        rowId: String,
+                        dateCellId: String,
+                        linkCellId: String)
+
+case class PdfLink(downloadURL: String, formattedSize: String, ariaText: String)
+
+object SecuritiesRequestedStatementsViewModel {
+  def prepareStatementRows(securityStatements: Seq[SecurityStatementsForEori])
+                          (implicit messages: Messages): Seq[StatementRow] = {
+
+    securityStatements.zipWithIndex.flatMap { case (statement, statementIndex) =>
+      statement.requestedStatements.sorted.zipWithIndex.map { case (requestedStatement, requestedIndex) =>
+
+        val eori = if (statementIndex > 0) Some(statement.eoriHistory.eori) else None
+
+        val date = messages("cf.security-statements.requested.period",
+          dateAsDayMonthAndYear(requestedStatement.startDate),
+          dateAsDayMonthAndYear(requestedStatement.endDate))
+
+        val pdf = requestedStatement.pdf.map { pdf =>
+          PdfLink(
+            downloadURL = pdf.downloadURL,
+            formattedSize = pdf.formattedSize,
+            ariaText = messages(
+              "cf.security-statements.requested.download-link.aria-text",
+              Pdf,
+              dateAsDayMonthAndYear(requestedStatement.startDate),
+              dateAsDayMonthAndYear(requestedStatement.endDate),
+              pdf.formattedSize
+            )
+          )
+        }
+
+        StatementRow(
+          historyIndex = statementIndex,
+          eori,
+          date,
+          pdf,
+          rowId = s"requested-statements-list-$statementIndex-row-$requestedIndex",
+          dateCellId = s"requested-statements-list-$statementIndex-row-$requestedIndex-date-cell",
+          linkCellId = s"requested-statements-list-$statementIndex-row-$requestedIndex-link-cell"
+        )
+      }
+    }
+  }
+
+  def renderEoriHeading(row: StatementRow)(implicit messages: Messages): Option[HtmlFormat.Appendable] = {
+    row.eori.map { eori =>
+      Html(
+        s"""<h2 id="requested-statements-eori-heading-${row.historyIndex}"
+           |    class="govuk-heading-s govuk-!-margin-bottom-2">
+           |  ${messages("cf.account.details.previous-eori", eori)}
+           |</h2>""".stripMargin)
+    }
+  }
+
+  def renderPdfLink(pdf: Option[PdfLink])(implicit messages: Messages): HtmlFormat.Appendable = {
+    pdf.fold(
+      Html(s"""<span class="file-link">${messages("cf.security-statements.no-statements", Pdf)}</span>""")
+    ) { link =>
+      Html(
+        s"""<a class="file-link govuk-link" href="${link.downloadURL}" download>
+           |<span>$Pdf (${link.formattedSize})</span>
+           |<span class="govuk-visually-hidden">${link.ariaText}</span>
+           |</a>""".stripMargin)
+    }
+  }
+}

--- a/app/viewmodels/SecuritiesRequestedStatementsViewModel.scala
+++ b/app/viewmodels/SecuritiesRequestedStatementsViewModel.scala
@@ -58,7 +58,7 @@ object SecuritiesRequestedStatementsViewModel {
     )
   }
 
-  def prepareStatementRows(securityStatements: Seq[SecurityStatementsForEori])
+  private def prepareStatementRows(securityStatements: Seq[SecurityStatementsForEori])
                           (implicit messages: Messages): Seq[StatementRow] = {
 
     for {
@@ -104,11 +104,11 @@ object SecuritiesRequestedStatementsViewModel {
     )
   }
 
-  def hasSecurityStatementsForEori(securityStatements: Seq[SecurityStatementsForEori]): Boolean = {
+  private def hasSecurityStatementsForEori(securityStatements: Seq[SecurityStatementsForEori]): Boolean = {
     securityStatements.exists(_.requestedStatements.nonEmpty)
   }
 
-  def renderEoriHeading(row: StatementRow)(implicit messages: Messages): Option[HtmlFormat.Appendable] = {
+  private def renderEoriHeading(row: StatementRow)(implicit messages: Messages): Option[HtmlFormat.Appendable] = {
     row.eori.map { eori =>
       h2Component(
         msg = messages("cf.account.details.previous-eori", eori),
@@ -118,7 +118,7 @@ object SecuritiesRequestedStatementsViewModel {
     }
   }
 
-  def renderPdfLink(pdf: Option[PdfLink])(implicit messages: Messages): Html = {
+  private def renderPdfLink(pdf: Option[PdfLink])(implicit messages: Messages): Html = {
     pdf.fold(
       spanComponent(
         key = s"${messages("cf.security-statements.no-statements", Pdf)}",
@@ -136,7 +136,7 @@ object SecuritiesRequestedStatementsViewModel {
     }
   }
 
-  def renderMissingDocumentsGuidance(implicit messages: Messages): HtmlFormat.Appendable = {
+  private def renderMissingDocumentsGuidance(implicit messages: Messages): HtmlFormat.Appendable = {
     missingDocumentsGuidanceComponent("statement")
   }
 }

--- a/app/views/SecuritiesRequestedStatements.scala.html
+++ b/app/views/SecuritiesRequestedStatements.scala.html
@@ -41,20 +41,20 @@
   content=Html(messages("cf.security-statements.requested.available.text"))
 )
 
-<dl class="govuk-summary-list statement-list">
+@for(row <- prepareStatementRows(statements)) {
+  @if(hasSecurityStatementsForEori(statements)) {
+    @renderEoriHeading(row)
 
-    @for(row <- prepareStatementRows(statements)) {
-        @renderEoriHeading(row)
+      <dl class="govuk-summary-list statement-list">
+          <div class="govuk-summary-list__row" id="@row.rowId">
+              <dt class="govuk-summary-list__value" id="@row.dateCellId">@row.date</dt>
+                <dd class="govuk-summary-list__actions" id="@row.linkCellId">
+                    @renderPdfLink(row.pdf)
+                </dd>
+          </div>
+      </dl>
+  }
+}
 
-        <div class="govuk-summary-list__row" id="@row.rowId">
-            <dt class="govuk-summary-list__value" id="@row.dateCellId">@row.date</dt>
-            <dd class="govuk-summary-list__actions" id="@row.linkCellId">
-                @renderPdfLink(row.pdf)
-            </dd>
-        </div>
-    }
-
-</dl>
-
-@missing_documents_guidance("statement")
+@renderMissingDocumentsGuidance
 }

--- a/app/views/SecuritiesRequestedStatements.scala.html
+++ b/app/views/SecuritiesRequestedStatements.scala.html
@@ -14,9 +14,8 @@
  * limitations under the License.
  *@
 
-@import helpers.Formatters.dateAsDayMonthAndYear
-@import models.FileFormat.Pdf
 @import views.html.templates.Layout
+@import viewmodels.SecuritiesRequestedStatementsViewModel._
 
 @this(
         layout: Layout,
@@ -32,66 +31,30 @@
 
 @layout(pageTitle = Some(messages("cf.security-statements.requested.title")), backLink = Some(backLink)) {
 
-@h1(id=Some("security-statements-heading"), classes="govuk-heading-xl govuk-!-margin-bottom-3", msg=messages("cf.security-statements.requested.title"))
+@h1(id=Some("security-statements-heading"),
+  classes="govuk-heading-xl govuk-!-margin-bottom-3",
+  msg=messages("cf.security-statements.requested.title")
+)
 
-@p(classes="govuk-body govuk-!-margin-bottom-8", id=Some("available-text"), content=Html(messages("cf.security-statements.requested.available.text")))
+@p(classes="govuk-body govuk-!-margin-bottom-8",
+  id=Some("available-text"),
+  content=Html(messages("cf.security-statements.requested.available.text"))
+)
 
-@for(historyIndex <- statements.indices) {
-    @if(statements(historyIndex).requestedStatements.nonEmpty) {
-        @if(historyIndex > 0) {
+<dl class="govuk-summary-list statement-list">
 
-            @h2(id=Some(s"requested-statements-eori-heading-${historyIndex}"),
-                classes="govuk-heading-s govuk-!-margin-bottom-2",
-                msg= messages("cf.account.details.previous-eori", statements(historyIndex).eoriHistory.eori)
-            )
-        }
+    @for(row <- prepareStatementRows(statements)) {
+        @renderEoriHeading(row)
 
-        <dl class="govuk-summary-list statement-list" id="requested-statements-list-@{
-            historyIndex
-        }">
-        @for((statementsOfOneMonth, index) <- statements(historyIndex).requestedStatements.sorted.zipWithIndex) {
-            <div class="govuk-summary-list__row" id="requested-statements-list-@{
-                historyIndex
-            }-row-@{
-                index
-            }">
-                <dt class="govuk-summary-list__value" id="requested-statements-list-@{
-                    historyIndex
-                }-row-@{
-                    index
-                }-date-cell">
-                @messages("cf.security-statements.requested.period",
-                    dateAsDayMonthAndYear(statementsOfOneMonth.startDate),
-                    dateAsDayMonthAndYear(statementsOfOneMonth.endDate))
-                </dt>
-                <dd class="govuk-summary-list__actions" id="requested-statements-list-@{
-                    historyIndex
-                }-row-@{
-                    index
-                }-link-cell">
-                @if(statementsOfOneMonth.pdf.isDefined) {
-                    <a class="file-link govuk-link" href="@{
-                        statementsOfOneMonth.pdf.get.downloadURL
-                    }" download>
-                        <span>
-                            @Pdf (@statementsOfOneMonth.pdf.get.formattedSize)
-                        </span>
-                         <span class="govuk-visually-hidden"> @messages("cf.security-statements.requested.download-link.aria-text",
-                            Pdf,
-                            dateAsDayMonthAndYear(statementsOfOneMonth.startDate),
-                            dateAsDayMonthAndYear(statementsOfOneMonth.endDate),
-                            statementsOfOneMonth.pdf.get.formattedSize)
-                        </span>
-                    </a>
-                } else {
-                    <span class="file-link">@messages("cf.security-statements.no-statements", Pdf)</span>
-                }
-                </dd>
-            </div>
-        }
-        </dl>
+        <div class="govuk-summary-list__row" id="@row.rowId">
+            <dt class="govuk-summary-list__value" id="@row.dateCellId">@row.date</dt>
+            <dd class="govuk-summary-list__actions" id="@row.linkCellId">
+                @renderPdfLink(row.pdf)
+            </dd>
+        </div>
     }
-}
+
+</dl>
 
 @missing_documents_guidance("statement")
 }

--- a/app/views/SecuritiesRequestedStatements.scala.html
+++ b/app/views/SecuritiesRequestedStatements.scala.html
@@ -42,7 +42,9 @@
 )
 
 @for(row <- model.statementRows) {
+
   @if(model.hasStatements) {
+
     @model.renderEoriHeading
 
       <dl class="govuk-summary-list statement-list">

--- a/app/views/SecuritiesRequestedStatements.scala.html
+++ b/app/views/SecuritiesRequestedStatements.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import views.html.templates.Layout
-@import viewmodels.SecuritiesRequestedStatementsViewModel._
+@import viewmodels.SecuritiesRequestedStatementsViewModel
 
 @this(
         layout: Layout,
@@ -27,7 +27,7 @@
         link2: components.link2
 )
 
-@(statements: Seq[SecurityStatementsForEori], backLink: String)(implicit request: Request[_], messages: Messages)
+@(model: SecuritiesRequestedStatementsViewModel, backLink: String)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = Some(messages("cf.security-statements.requested.title")), backLink = Some(backLink)) {
 
@@ -41,20 +41,20 @@
   content=Html(messages("cf.security-statements.requested.available.text"))
 )
 
-@for(row <- prepareStatementRows(statements)) {
-  @if(hasSecurityStatementsForEori(statements)) {
-    @renderEoriHeading(row)
+@for(row <- model.statementRows) {
+  @if(model.hasStatements) {
+    @model.renderEoriHeading
 
       <dl class="govuk-summary-list statement-list">
           <div class="govuk-summary-list__row" id="@row.rowId">
               <dt class="govuk-summary-list__value" id="@row.dateCellId">@row.date</dt>
                 <dd class="govuk-summary-list__actions" id="@row.linkCellId">
-                    @renderPdfLink(row.pdf)
+                    @model.renderPdfLink
                 </dd>
           </div>
       </dl>
   }
 }
 
-@renderMissingDocumentsGuidance
+@model.renderMissingDocumentsGuidance
 }

--- a/app/views/SecuritiesRequestedStatements.scala.html
+++ b/app/views/SecuritiesRequestedStatements.scala.html
@@ -19,12 +19,9 @@
 
 @this(
         layout: Layout,
-        download_link: components.download_link,
         missing_documents_guidance: components.missing_documents_guidance,
         h1: components.h1,
-        h2: components.h2,
-        p: components.p,
-        link2: components.link2
+        p: components.p
 )
 
 @(model: SecuritiesRequestedStatementsViewModel, backLink: String)(implicit request: Request[_], messages: Messages)

--- a/app/views/components/span_link.scala.html
+++ b/app/views/components/span_link.scala.html
@@ -14,6 +14,8 @@
  * limitations under the License.
  *@
 
+@import utils.Utils.emptyString
+
 @this()
 
 @(msg: String,
@@ -24,9 +26,9 @@
   spanMsg: Option[String] = None
 )(implicit messages: Messages)
 
-<a @{id.fold("")(id => s"id=$id")} href="@url" class="@classes">
+<a @{id.fold(emptyString)(id => s"id=$id")} href="@url" class="@classes">
     @messages(msg)
-    <span @{spanClass.fold("")(spanClass => s"class=$spanClass")}>
-        @{spanMsg.fold("")(spanMsg => s"$spanMsg")}
+    <span @{spanClass.fold(emptyString)(spanClass => s"class=$spanClass")}>
+        @{spanMsg.fold(emptyString)(spanMsg => s"$spanMsg")}
   </span>
 </a>

--- a/app/views/components/span_link.scala.html
+++ b/app/views/components/span_link.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,17 @@
 
 @this()
 
-@(key: String, classes: Option[String], visuallyHidden: Boolean = true)(implicit messages: Messages)
+@(msg: String,
+  id: Option[String] = None,
+  classes: String = "govuk-link",
+  url: String,
+  spanClass: Option[String] = None,
+  spanMsg: Option[String] = None
+)(implicit messages: Messages)
 
-@if(visuallyHidden){
-    <span class="govuk-visually-hidden">@messages(key)</span>
-} else {
-    <span>@messages(key)</span>
-}
+<a @{id.fold("")(id => s"id=$id")} href="@url" class="@classes">
+    @messages(msg)
+    <span @{spanClass.fold("")(spanClass => s"class=$spanClass")}>
+        @{spanMsg.fold("")(spanMsg => s"$spanMsg")}
+  </span>
+</a>

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val it = project
   .settings(libraryDependencies ++= Seq("uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % Test))
 
 lazy val root = (project in file("."))
-  .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtDistributablesPlugin)
+  .enablePlugins(PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin)
   .settings(DefaultBuildSettings.scalaSettings *)
   .settings(DefaultBuildSettings.defaultSettings() *)

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -14,34 +14,12 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="ACCESS_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/access.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/connector.log</file>
         <encoder>
             <pattern>%message%n</pattern>
         </encoder>
     </appender>
-
-
-    <logger name="accesslog" level="INFO" additivity="false">
-        <appender-ref ref="ACCESS_LOG_FILE" />
-    </logger>
-
-    <logger name="com.ning.http.client.providers.netty" additivity="false">
-        <appender-ref ref="STDOUT_IGNORE_NETTY" />
-    </logger>
 
     <logger name="com.google.inject" level="INFO"/>
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.21.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.22.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")

--- a/test/viewmodels/SecuritiesRequestedStatementsViewModelSpec.scala
+++ b/test/viewmodels/SecuritiesRequestedStatementsViewModelSpec.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels
+
+import base.SpecBase
+import play.api.i18n.Messages
+import models.{EoriHistory, SecurityStatementsByPeriod, SecurityStatementsForEori}
+
+import java.time.LocalDate
+
+class SecuritiesRequestedStatementsViewModelSpec extends Setup {
+
+  when(mockMessages("cf.account.details.previous-eori", "EORI456"))
+    .thenReturn("Previous EORI: EORI456")
+
+  "prepareStatementRows" should {
+    "return a sequence of StatementRow" in {
+      val result = SecuritiesRequestedStatementsViewModel.prepareStatementRows(securityStatements)
+
+      result mustBe Seq(
+        StatementRow(
+          historyIndex = 0,
+          eori = None,
+          date = "",
+          pdf = None,
+          rowId = "requested-statements-list-0-row-0",
+          dateCellId = "requested-statements-list-0-row-0-date-cell",
+          linkCellId = "requested-statements-list-0-row-0-link-cell"
+        )
+      )
+    }
+  }
+
+  "renderEoriHeading" should {
+    "render the EORI" in {
+      val row = StatementRow(
+        0,
+        Some("EORI456"),
+        "10 July 2023 to 20 July 2023",
+        Some(pdfLink),
+        "rowId",
+        "dateCellId",
+        "linkCellId"
+      )
+
+      val result = SecuritiesRequestedStatementsViewModel.renderEoriHeading(row)
+
+      result.map(_.body.trim) mustBe Some(
+        """<h2 id="requested-statements-eori-heading-0"
+          |    class="govuk-heading-s govuk-!-margin-bottom-2">
+          |  Previous EORI: EORI456
+          |</h2>""".stripMargin.trim)
+    }
+
+    "return None when EORI is not present" in {
+      val row = StatementRow(
+        0,
+        None,
+        "10 July 2023 to 20 July 2023",
+        Some(pdfLink),
+        "rowId",
+        "dateCellId",
+        "linkCellId"
+      )
+
+      val result = SecuritiesRequestedStatementsViewModel.renderEoriHeading(row)
+
+      result mustBe None
+    }
+  }
+
+  "renderPdfLink" should {
+    "render the correct PDF link" in {
+      val pdf = Some(pdfLink)
+      val result = SecuritiesRequestedStatementsViewModel.renderPdfLink(pdf)
+
+      result.body.trim mustBe
+        s"""<a class="file-link govuk-link" href="${pdfLink.downloadURL}" download>
+           |<span>PDF (${pdfLink.formattedSize})</span>
+           |<span class="govuk-visually-hidden">Download PDF</span>
+           |</a>""".stripMargin.trim
+    }
+  }
+}
+
+trait Setup extends SpecBase {
+  implicit val mockMessages: Messages = mock[Messages]
+
+  val pdfLink: PdfLink = PdfLink("file.pdf", "1MB", "Download PDF")
+
+  val requestedStatement: SecurityStatementsByPeriod = SecurityStatementsByPeriod(
+    startDate = LocalDate.parse("2023-07-10"),
+    endDate = LocalDate.parse("2023-07-20"),
+    files = Seq.empty
+  )
+
+  val securityStatementForEori: SecurityStatementsForEori = SecurityStatementsForEori(
+    eoriHistory = EoriHistory("EORI456", Some(LocalDate.parse("2023-07-10")), Some(LocalDate.parse("2023-07-20"))),
+    currentStatements = Seq(requestedStatement),
+    requestedStatements = Seq(requestedStatement)
+  )
+
+  val securityStatements: Seq[SecurityStatementsForEori] = Seq(securityStatementForEori)
+}

--- a/test/views/components/SpanLinkSpec.scala
+++ b/test/views/components/SpanLinkSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import views.ViewTestHelper
+import views.html.components.span_link
+
+class SpanLinkSpec extends ViewTestHelper {
+
+  "SpanLink component" should {
+    "display the span message" when {
+      "spanMsg is set and visually hidden" in new Setup {
+        implicit val spanView: Document = view(spanMsg = Some(msgKey), spanClass = Some("govuk-visually-hidden"))
+        displayVisuallyHiddenMessage()
+      }
+
+      "spanMsg is set and not visually hidden" in new Setup {
+        implicit val spanView: Document = view(spanMsg = Some(msgKey), spanClass = None)
+        shouldNotDisplayVisuallyHiddenMessage()
+        shouldDisplaySpanWithMessageKey()
+      }
+
+      "spanMsg is not set" in new Setup {
+        implicit val spanView: Document = view(spanMsg = None)
+        shouldNotDisplaySpanMessage()
+      }
+    }
+
+    "render the span link with an id attribute set" in new Setup {
+      implicit val spanView: Document = view(
+        spanMsg = Some(msgKey),
+        spanClass = Some("govuk-visually-hidden"),
+        id = Some("govuk-id")
+      )
+      shouldRenderLinkWithId()
+    }
+  }
+
+  private def displayVisuallyHiddenMessage(msgKey: String = "timeout.title")(implicit view: Document) = {
+    view.getElementsByClass("govuk-visually-hidden").text() mustBe msgKey
+  }
+
+  private def shouldNotDisplayVisuallyHiddenMessage()(implicit view: Document) = {
+    view.getElementsByClass("govuk-visually-hidden").text() mustBe empty
+  }
+
+  private def shouldDisplaySpanWithMessageKey(msgKey: String = "timeout.title")(implicit view: Document) = {
+    view.getElementsByTag("span").text() mustBe msgKey
+  }
+
+  private def shouldNotDisplaySpanMessage()(implicit view: Document) = {
+    view.getElementsByTag("span").text() mustBe empty
+  }
+
+  private def shouldRenderLinkWithId(msgKey: String = "timeout.title")(implicit view: Document) = {
+    view.getElementsByTag("a").attr("id") mustBe "govuk-id"
+    view.getElementsByTag("span").text() mustBe msgKey
+    view.getElementsByClass("govuk-visually-hidden").text() mustBe msgKey
+  }
+
+  trait Setup {
+
+    val msgKey = "timeout.title"
+    val url = "/example"
+
+    def view(msgKey: String = msgKey,
+             spanMsg: Option[String] = None,
+             spanClass: Option[String] = None,
+             id: Option[String] = None): Document = {
+
+      val component = app.injector.instanceOf[span_link].apply(
+        msg = msgKey,
+        url = url,
+        spanMsg = spanMsg,
+        spanClass = spanClass,
+        id = id
+      )
+
+      Jsoup.parse(component.body)
+    }
+  }
+}

--- a/test/views/components/SpanSpec.scala
+++ b/test/views/components/SpanSpec.scala
@@ -18,6 +18,7 @@ package views.components
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import utils.Utils.emptyString
 import views.ViewTestHelper
 import views.html.components.span
 
@@ -54,6 +55,6 @@ class SpanSpec extends ViewTestHelper {
     val messageKey = "timeout.title"
 
     def view(msgKey: String = messageKey, visuallyHidden: Boolean = true): Document = Jsoup.parse(
-      app.injector.instanceOf[span].apply(key = msgKey, classes = Some(""), visuallyHidden = visuallyHidden).body)
+      app.injector.instanceOf[span].apply(key = msgKey, classes = Some(emptyString), visuallyHidden = visuallyHidden).body)
   }
 }

--- a/test/views/components/SpanSpec.scala
+++ b/test/views/components/SpanSpec.scala
@@ -54,6 +54,6 @@ class SpanSpec extends ViewTestHelper {
     val messageKey = "timeout.title"
 
     def view(msgKey: String = messageKey, visuallyHidden: Boolean = true): Document = Jsoup.parse(
-      app.injector.instanceOf[span].apply(key = msgKey, visuallyHidden = visuallyHidden).body)
+      app.injector.instanceOf[span].apply(key = msgKey, classes = Some(""), visuallyHidden = visuallyHidden).body)
   }
 }


### PR DESCRIPTION
Tasks:

- Move logic from **views/SecuritiesRequestedStatements.scala.html** to View Model.
- Add unit tests.