### PR TITLE
MMCA-4812-Issue | Fixed so PDF's are generating the right attachment

### DIFF
--- a/app/viewmodels/SecuritiesRequestedStatementsViewModel.scala
+++ b/app/viewmodels/SecuritiesRequestedStatementsViewModel.scala
@@ -30,13 +30,13 @@ case class StatementRow(historyIndex: Int,
                         rowId: String,
                         dateCellId: String,
                         linkCellId: String,
-                        eoriHeading: Option[HtmlFormat.Appendable])
+                        renderEoriHeading: Option[HtmlFormat.Appendable],
+                        renderPdfLink: Html)
 
 case class PdfLink(downloadURL: String, formattedSize: String, ariaText: String)
 
 case class SecuritiesRequestedStatementsViewModel(statementRows: Seq[StatementRow],
                                                   hasStatements: Boolean,
-                                                  renderPdfLink: Option[Html],
                                                   renderMissingDocumentsGuidance: HtmlFormat.Appendable)
 
 object SecuritiesRequestedStatementsViewModel {
@@ -46,12 +46,10 @@ object SecuritiesRequestedStatementsViewModel {
 
     val preparedStatementRows = prepareStatementRows(securityStatementsForEori)
     val hasStatements = hasSecurityStatementsForEori(securityStatementsForEori)
-    val pdfLink = preparedStatementRows.headOption.map(row => renderPdfLink(row.pdf))
 
     SecuritiesRequestedStatementsViewModel(
       statementRows = preparedStatementRows,
       hasStatements = hasStatements,
-      renderPdfLink = pdfLink,
       renderMissingDocumentsGuidance = renderMissingDocumentsGuidance
     )
   }
@@ -72,7 +70,7 @@ object SecuritiesRequestedStatementsViewModel {
 
     val eori = if (statementIndex > 0) Some(statement.eoriHistory.eori) else None
 
-    val eoriHeading = eori.map { eori =>
+    val renderEoriHeading = eori.map { eori =>
       h2Component(
         msg = messages("cf.account.details.previous-eori", eori),
         id = Some(s"requested-statements-eori-heading-$statementIndex"),
@@ -106,7 +104,8 @@ object SecuritiesRequestedStatementsViewModel {
       rowId = s"requested-statements-list-$statementIndex-row-$requestedIndex",
       dateCellId = s"requested-statements-list-$statementIndex-row-$requestedIndex-date-cell",
       linkCellId = s"requested-statements-list-$statementIndex-row-$requestedIndex-link-cell",
-      eoriHeading = eoriHeading
+      renderEoriHeading,
+      renderPdfLink(pdf)
     )
   }
 

--- a/app/views/SecuritiesRequestedStatements.scala.html
+++ b/app/views/SecuritiesRequestedStatements.scala.html
@@ -42,13 +42,13 @@
 
   @if(model.hasStatements) {
 
-    @row.eoriHeading
+    @row.renderEoriHeading
 
       <dl class="govuk-summary-list statement-list">
           <div class="govuk-summary-list__row" id="@row.rowId">
               <dt class="govuk-summary-list__value" id="@row.dateCellId">@row.date</dt>
                 <dd class="govuk-summary-list__actions" id="@row.linkCellId">
-                    @model.renderPdfLink
+                    @row.renderPdfLink
                 </dd>
           </div>
       </dl>

--- a/test/viewmodels/SecuritiesRequestedStatementsViewModelSpec.scala
+++ b/test/viewmodels/SecuritiesRequestedStatementsViewModelSpec.scala
@@ -261,4 +261,5 @@ trait SpecBaseWithSetup extends SpecBase {
 
   when(messages("cf.account.details.previous-eori", eoriNumber))
     .thenReturn(s"Previous EORI: $eoriNumber")
+
 }


### PR DESCRIPTION
Problem:
- PDF's not generating the right attachment for each row.

Task:
- Pass renderPdfLink method to StatementRow class so it generates the right PDF for different row.