### PR TITLE
MMCA-4812-Spacing | Added download attribute, neccessary spacing

### DIFF
--- a/app/viewmodels/SecuritiesRequestedStatementsViewModel.scala
+++ b/app/viewmodels/SecuritiesRequestedStatementsViewModel.scala
@@ -128,7 +128,8 @@ object SecuritiesRequestedStatementsViewModel {
         url = link.downloadURL,
         classes = "file-link govuk-link",
         spanMsg = Some(link.ariaText),
-        spanClass = Some("govuk-visually-hidden")
+        spanClass = Some("govuk-visually-hidden"),
+        download = true
       )
     }
   }

--- a/app/views/SecuritiesRequestedStatements.scala.html
+++ b/app/views/SecuritiesRequestedStatements.scala.html
@@ -46,7 +46,7 @@
 
       <dl class="govuk-summary-list statement-list" id="@row.dlRowId">
           <div class="govuk-summary-list__row" id="@row.rowId">
-              <dt class="govuk-summary-list__value" id="@row.dateCellId">@row.date</dt>
+              <dt class="govuk-summary-list__value" id="@row.dateCellId"> @row.date </dt>
                 <dd class="govuk-summary-list__actions" id="@row.linkCellId">
                     @row.renderPdfLink
                 </dd>

--- a/app/views/components/span_link.scala.html
+++ b/app/views/components/span_link.scala.html
@@ -23,11 +23,12 @@
   classes: String = "govuk-link",
   url: String,
   spanClass: Option[String] = None,
-  spanMsg: Option[String] = None
+  spanMsg: Option[String] = None,
+  download: Boolean = false
 )(implicit messages: Messages)
 
-<a @{id.fold(emptyString)(id => s"id=$id")} href="@url" class="@classes">
-    @messages(msg)
+<a @{id.fold(emptyString)(id => s"id=$id")} class="@classes" href="@url" @if(download) {download}>
+    <span> @messages(msg) </span>
     <span @{spanClass.fold(emptyString)(spanClass => s"class=$spanClass")}>
         @{spanMsg.fold(emptyString)(spanMsg => s"$spanMsg")}
   </span>

--- a/test/views/components/SpanLinkSpec.scala
+++ b/test/views/components/SpanLinkSpec.scala
@@ -27,13 +27,13 @@ class SpanLinkSpec extends ViewTestHelper {
     "display the span message" when {
       "spanMsg is set and visually hidden" in new Setup {
         implicit val spanView: Document = view(spanMsg = Some(msgKey), spanClass = Some("govuk-visually-hidden"))
-        displayVisuallyHiddenMessage()
+        displayVisuallyHiddenMessage(msgKey)
       }
 
       "spanMsg is set and not visually hidden" in new Setup {
         implicit val spanView: Document = view(spanMsg = Some(msgKey), spanClass = None)
         shouldNotDisplayVisuallyHiddenMessage()
-        shouldDisplaySpanWithMessageKey()
+        shouldDisplaySpanWithMessageKey(msgKey)
       }
 
       "spanMsg is not set" in new Setup {
@@ -48,30 +48,31 @@ class SpanLinkSpec extends ViewTestHelper {
         spanClass = Some("govuk-visually-hidden"),
         id = Some("govuk-id")
       )
-      shouldRenderLinkWithId()
+
+      shouldRenderLinkWithId("govuk-id", msgKey)
     }
   }
 
-  private def displayVisuallyHiddenMessage(msgKey: String = "timeout.title")(implicit view: Document) = {
-    view.getElementsByClass("govuk-visually-hidden").text() mustBe msgKey
+  private def displayVisuallyHiddenMessage(expectedMsg: String)(implicit view: Document) = {
+    view.getElementsByClass("govuk-visually-hidden").text() mustBe expectedMsg.trim
   }
 
   private def shouldNotDisplayVisuallyHiddenMessage()(implicit view: Document) = {
     view.getElementsByClass("govuk-visually-hidden").text() mustBe empty
   }
 
-  private def shouldDisplaySpanWithMessageKey(msgKey: String = "timeout.title")(implicit view: Document) = {
-    view.getElementsByTag("span").text() mustBe msgKey
+  private def shouldDisplaySpanWithMessageKey(expectedMsg: String)(implicit view: Document) = {
+    view.getElementsByTag("span").last().text() mustBe expectedMsg.trim
   }
 
   private def shouldNotDisplaySpanMessage()(implicit view: Document) = {
-    view.getElementsByTag("span").text() mustBe empty
+    view.getElementsByTag("span").last().text() mustBe empty
   }
 
-  private def shouldRenderLinkWithId(msgKey: String = "timeout.title")(implicit view: Document) = {
-    view.getElementsByTag("a").attr("id") mustBe "govuk-id"
-    view.getElementsByTag("span").text() mustBe msgKey
-    view.getElementsByClass("govuk-visually-hidden").text() mustBe msgKey
+  private def shouldRenderLinkWithId(expectedId: String, expectedMsg: String)(implicit view: Document) = {
+    view.getElementsByTag("a").attr("id") mustBe expectedId
+    view.getElementsByTag("span").last().text() mustBe expectedMsg.trim
+    view.getElementsByClass("govuk-visually-hidden").text() mustBe expectedMsg.trim
   }
 
   trait Setup {


### PR DESCRIPTION
Problem:
- Needed necessary spacing as it was present in development environment. download attribute at the end of href. span component wrap.

Task:
- Add necessary spacing on message. Download attribute at the end of href. Wrap PDF message in span.