### PR TITLE
[MMCA-4878-4879-4880] - Amend historic statements date picker screen for DD, PVAT and Security Statements

### DIFF
--- a/app/models/DateMessages.scala
+++ b/app/models/DateMessages.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+case class DateMessage(labelMsgKey: String, hintMsgKey: String)
+
+case class DateMessages(startDate: DateMessage, endDate: DateMessage)
+
+object DateMessages {
+
+  def apply(fileRole: FileRole): DateMessages = {
+
+    fileRole match {
+      case C79Certificate =>
+        DateMessages(
+          startDate =
+            DateMessage("cf.historic.document.request.from", "cf.historic.document.request.date.C79Certificate.hint"),
+
+          endDate = DateMessage("cf.historic.document.request.to", "cf.historic.document.request.endDate.hint")
+        )
+
+      case PostponedVATStatement =>
+        DateMessages(
+          startDate =
+            DateMessage(
+              "cf.historic.document.request.from", "cf.historic.document.request.date.PostponedVATStatement.hint"),
+
+          endDate =
+            DateMessage("cf.historic.document.request.to", "cf.historic.document.request.endDate.hint")
+        )
+
+      case DutyDefermentStatement =>
+        DateMessages(
+          startDate =
+            DateMessage(
+              "cf.historic.document.request.from", "cf.historic.document.request.date.DutyDefermentStatement.hint"),
+
+          endDate =
+            DateMessage("cf.historic.document.request.to", "cf.historic.document.request.endDate.hint")
+        )
+
+      case SecurityStatement =>
+        DateMessages(
+          startDate =
+            DateMessage("cf.historic.document.request.from", "cf.historic.document.request.date.SecurityStatement.hint"),
+
+          endDate =
+            DateMessage("cf.historic.document.request.to", "cf.historic.document.request.endDate.hint")
+        )
+    }
+  }
+}

--- a/app/views/HistoricDateRequestPageView.scala.html
+++ b/app/views/HistoricDateRequestPageView.scala.html
@@ -16,6 +16,7 @@
 
 @import views.html.templates.Layout
 @import helpers.FormHelper.updateFormErrorKeyForStartAndEndDate
+@import models.DateMessages
 
 
 @this(
@@ -33,6 +34,7 @@
     mode: Mode,
     fileRole: FileRole,
     returnUrl: String,
+    dateMessages: DateMessages,
     maybeDan: Option[String],
     niIndicator: Option[Boolean]
 )(implicit request: Request[_], messages: Messages)
@@ -54,41 +56,28 @@
     }
 
     @formHelper(action = controllers.routes.HistoricDateRequestPageController.onSubmit(mode, fileRole), Symbol("autoComplete") -> "off") {
+
         @errorSummary(form.errors,errorFieldName = None, isErrorKeyUpdateEnabled = true, Some(updateFormErrorKeyForStartAndEndDate()))
 
-            @h1(s"cf.historic.document.request.heading.$fileRole")        
+            @h1(s"cf.historic.document.request.heading.$fileRole")
+
             @p(Html(messages(s"cf.historic.document.request.info-text.$fileRole")))
 
-            @if(fileRole != C79Certificate){
+            @defining(dateMessages.startDate) { date =>
                 @inputDate(
                     form,
-                    messages("cf.historic.document.request.from.statements"),
-                    hintText = Some(messages("cf.historic.document.request.date.pvat.hint")),
+                    messages(date.labelMsgKey),
+                    hintText = Some(messages(date.hintMsgKey)),
                     id = "start",
                     legendAsPageHeading = false,
                 )
+            }
 
+            @defining(dateMessages.endDate) { date =>
                 @inputDate(
                     form,
-                    messages("cf.historic.document.request.to.statements"),
-                    hintText = Some(messages("cf.historic.document.request.date.pvat.hint")),
-                    id = "end",
-                    legendAsPageHeading = false,
-                )
-
-            } else {
-                @inputDate(
-                    form,
-                    messages("cf.historic.document.request.from"),
-                    hintText = Some(messages("cf.historic.document.request.date.hint")),
-                    id = "start",
-                    legendAsPageHeading = false,
-                )
-
-                @inputDate(
-                    form,
-                    messages("cf.historic.document.request.to"),
-                    hintText = Some(messages("cf.historic.document.request.date.pvat.hint")),
+                    messages(date.labelMsgKey),
+                    hintText = Some(messages(date.hintMsgKey)),
                     id = "end",
                     legendAsPageHeading = false,
                 )

--- a/app/views/HistoricDateRequestPageView.scala.html
+++ b/app/views/HistoricDateRequestPageView.scala.html
@@ -18,7 +18,6 @@
 @import helpers.FormHelper.updateFormErrorKeyForStartAndEndDate
 @import models.DateMessages
 
-
 @this(
         layout: Layout,
         formHelper: FormWithCSRF,

--- a/app/views/HistoricDateRequestPageView.scala.html
+++ b/app/views/HistoricDateRequestPageView.scala.html
@@ -28,7 +28,14 @@
         p: components.p
 )
 
-@(form: Form[_], mode: Mode, fileRole: FileRole, returnUrl: String, maybeDan: Option[String], niIndicator: Option[Boolean])(implicit request: Request[_], messages: Messages)
+@(
+    form: Form[_],
+    mode: Mode,
+    fileRole: FileRole,
+    returnUrl: String,
+    maybeDan: Option[String],
+    niIndicator: Option[Boolean]
+)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = Some(title(form, messages(s"cf.historic.document.request.${fileRole}.title"))),
         backLinkUrl = Some(returnUrl),

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -78,26 +78,29 @@ cf.historic.document.request.heading.PostponedVATStatement=Pa ddatganiadau ar gy
 cf.historic.document.request.heading.SecurityStatement=Pa hysbysiad o ddatganiadau addasu sydd eu hangen arnoch?
 cf.historic.document.request.heading.DutyDefermentStatement=Pa ddatganiadau gohirio tollau sydd eu hangen arnoch?
 
-cf.historic.document.request.info-text.C79Certificate=Gallwch ofyn am hyd at 6 mis o dystysgrifau TAW mewnforio ar y tro.
-cf.historic.document.request.info-text.PostponedVATStatement=Gallwch wneud cais am ddatganiadau TAW mewnforio ohiriedig am hyd at 6 mis y tro o fis Ionawr 2021 ymlaen.
-cf.historic.document.request.info-text.SecurityStatement=Gallwch wneud cais am hysbysiad o ddatganiadau addasu am hyd at 6 mis y tro o fis Hydref 2019 ymlaen.
-cf.historic.document.request.info-text.DutyDefermentStatement=Gallwch wneud cais am dystysgrifau TAW mewnforio am hyd at 6 mis y tro o fis Hydref 2019 ymlaen.
+cf.historic.document.request.info-text.C79Certificate = Gallwch ofyn am hyd at 6 mis o dystysgrifau TAW mewnforio ar y tro.
+cf.historic.document.request.info-text.PostponedVATStatement = Gallwch ofyn am hyd at 6 mis o ddatganiadau TAW mewnforio ohiriedig ar y tro.
+cf.historic.document.request.info-text.SecurityStatement = Gallwch ofyn am hyd at 6 mis o hysbysiad o ddatganiadau addasu ar y tro.
+cf.historic.document.request.info-text.DutyDefermentStatement = Gallwch ofyn am hyd at 6 mis o ddatganiadau gohirio tollau ar y tro.
 cf.historic.document.request.continue=Yn eich blaen
 
 cf.historic.document.request.from=Dyddiad dechrau
-cf.historic.document.request.from.statements=O ba ddyddiad dechrau y mae angen datganiadau arnoch?
 cf.historic.document.request.whichStartDate.C79Certificate=ar gyfer pa ddyddiad dechrau y mae angen tystysgrifau TAW mewnforio arnoch?
 cf.historic.document.request.whichStartDate.PostponedVATStatement=ar gyfer pa ddyddiad dechrau y mae angen tystysgrifau TAW o ddatganiadau addasu arnoch?
 cf.historic.document.request.whichStartDate.SecurityStatement=ar gyfer pa ddyddiad dechrau y mae angen hysbysiad o ddatganiadau addasu arnoch?
 cf.historic.document.request.whichStartDate.DutyDefermentStatement=Ar gyfer pa ddyddiad dechrau y mae angen datganiadau gohirio tollau arnoch?
+cf.historic.document.request.date.C79Certificate.hint = Mae’n rhaid i’r dyddiad dechrau fod ar ôl Hydref 2019. Er enghraifft, 3 2021.
+cf.historic.document.request.date.PostponedVATStatement.hint = Mae’n rhaid i’r dyddiad dechrau fod ar ôl Ionawr 2021. Er enghraifft, 3 2021.
+cf.historic.document.request.date.DutyDefermentStatement.hint = Mae’n rhaid i’r dyddiad dechrau fod ar ôl Ionawr 2021. Er enghraifft, 3 2021.
+cf.historic.document.request.date.SecurityStatement.hint = Mae’n rhaid i’r dyddiad dechrau fod ar ôl Hydref 2019. Er enghraifft, 3 2021.
+
 cf.historic.document.request.to=Dyddiad dod i ben
 cf.historic.document.request.to.statements=I ba ddyddiad dod i ben y mae angen datganiadau arnoch?
 cf.historic.document.request.whichEndDate.C79Certificate=ar gyfer pa ddyddiad dod i ben y mae angen tystysgrifau TAW mewnforio arnoch?
 cf.historic.document.request.whichEndDate.PostponedVATStatement=ar gyfer pa ddyddiad dod i ben y mae angen tystysgrifau TAW o ddatganiadau addasu arnoch?
 cf.historic.document.request.whichEndDate.SecurityStatement=ar gyfer pa ddyddiad dod i ben y mae angen hysbysiad o ddatganiadau addasu arnoch?
 cf.historic.document.request.whichEndDate.DutyDefermentStatement=ar gyfer pa ddyddiad dod i ben y mae angen datganiadau gohirio tollau arnoch?
-cf.historic.document.request.date.hint=Mae’n rhaid i’r dyddiad dechrau fod ar ôl Hydref 2019. Er enghraifft, 3 2021.
-cf.historic.document.request.date.pvat.hint=Er enghraifft, 3 2021.
+cf.historic.document.request.endDate.hint = Er enghraifft, 3 2021.
 
 cf.historic.document.request.whichEndDate.C79Certificate.hidden = pa ddyddiad dod i ben sydd ei angen arnoch ar gyfer Tystysgrifau TAW mewnforio?
 cf.historic.document.request.whichStartDate.C79Certificate.hidden = pa ddyddiad dechrau sydd ei angen arnoch ar gyfer Tystysgrifau TAW mewnforio?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -78,26 +78,29 @@ cf.historic.document.request.heading.PostponedVATStatement=Which postponed impor
 cf.historic.document.request.heading.SecurityStatement=Which notification of adjustment statements do you need?
 cf.historic.document.request.heading.DutyDefermentStatement=Which duty deferment statements do you need?
 
-cf.historic.document.request.info-text.C79Certificate=You can request up to 6 months of import VAT certificates at a time.
-cf.historic.document.request.info-text.PostponedVATStatement=You can request postponed import VAT statements for up to 6 months at a time from January 2021.
-cf.historic.document.request.info-text.SecurityStatement=You can request notification of adjustment statements for up to 6 months at a time from October 2019.
-cf.historic.document.request.info-text.DutyDefermentStatement=You can request duty deferment statements for up to 6 months at a time from September 2019.
+cf.historic.document.request.info-text.C79Certificate = You can request up to 6 months of import VAT certificates at a time.
+cf.historic.document.request.info-text.PostponedVATStatement = You can request up to 6 months of postponed import VAT statements at a time.
+cf.historic.document.request.info-text.SecurityStatement = You can request up to 6 months of notification of adjustment statements at a time.
+cf.historic.document.request.info-text.DutyDefermentStatement = You can request up to 6 months of duty deferment statements at a time.
 cf.historic.document.request.continue=Continue
 
 cf.historic.document.request.from=Start date
-cf.historic.document.request.from.statements=From what start date do you need statements?
 cf.historic.document.request.whichStartDate.C79Certificate=which start date do you need Import VAT certificates?
 cf.historic.document.request.whichStartDate.PostponedVATStatement=which start date do you need Import Postponed VAT statements?
 cf.historic.document.request.whichStartDate.SecurityStatement=which start date do you need adjustment statements?
 cf.historic.document.request.whichStartDate.DutyDefermentStatement=which start date do you need deferment statements?
+cf.historic.document.request.date.C79Certificate.hint = Start date must be after October 2019. For example, 3 2021.
+cf.historic.document.request.date.PostponedVATStatement.hint = Start date must be after January 2021. For example, 3 2021.
+cf.historic.document.request.date.DutyDefermentStatement.hint = Start date must be after September 2019. For example, 3 2021.
+cf.historic.document.request.date.SecurityStatement.hint = Start date must be after October 2019. For example, 3 2021.
+
 cf.historic.document.request.to=End date
 cf.historic.document.request.to.statements=To what end date do you need statements?
 cf.historic.document.request.whichEndDate.C79Certificate=which end date do you need Import VAT certificates?
 cf.historic.document.request.whichEndDate.PostponedVATStatement=which start date do you need Import Postponed VAT statements?
 cf.historic.document.request.whichEndDate.SecurityStatement=which end date do you need adjustment statements?
 cf.historic.document.request.whichEndDate.DutyDefermentStatement=which end date do you need deferment statements?
-cf.historic.document.request.date.hint=Start date must be after October 2019. For example, 3 2021.
-cf.historic.document.request.date.pvat.hint=For example, 3 2021.
+cf.historic.document.request.endDate.hint = For example, 3 2021.
 
 cf.historic.document.request.whichEndDate.C79Certificate.hidden = what end date do you need Import VAT certificates?
 cf.historic.document.request.whichStartDate.C79Certificate.hidden = what start date do you need Import VAT certificates?

--- a/test/controllers/HistoricDateRequestPageControllerSpec.scala
+++ b/test/controllers/HistoricDateRequestPageControllerSpec.scala
@@ -18,7 +18,6 @@ package controllers
 
 import base.SpecBase
 import config.FrontendAppConfig
-import forms.HistoricDateRequestPageFormProvider
 import models.*
 import org.scalatest.TryValues.convertTryToSuccessOrFailure
 import pages.{HistoricDateRequestPage, RequestedLinkId}
@@ -28,7 +27,6 @@ import repositories.SessionRepository
 import utils.Utils.emptyString
 import org.mockito.Mockito.when
 import org.mockito.ArgumentMatchers.any
-import play.api.data.Form
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test.FakeRequest

--- a/test/models/DateMessagesSpec.scala
+++ b/test/models/DateMessagesSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import base.SpecBase
+
+class DateMessagesSpec extends SpecBase {
+
+  "DateMessages" should {
+
+    "populate the model correctly" when {
+
+      "fileRole is DutyDefermentStatement" in {
+        val actual = DateMessages(DutyDefermentStatement)
+
+        actual.startDate mustBe DateMessage(
+          labelMsgKey = "cf.historic.document.request.from",
+          hintMsgKey = "cf.historic.document.request.date.DutyDefermentStatement.hint")
+
+        actual.endDate mustBe DateMessage(
+          labelMsgKey = "cf.historic.document.request.to",
+          hintMsgKey = "cf.historic.document.request.endDate.hint")
+      }
+
+      "fileRole is C79Certificate" in {
+        val actual = DateMessages(C79Certificate)
+
+        actual.startDate mustBe DateMessage(
+          labelMsgKey = "cf.historic.document.request.from",
+          hintMsgKey = "cf.historic.document.request.date.C79Certificate.hint")
+
+        actual.endDate mustBe DateMessage(
+          labelMsgKey = "cf.historic.document.request.to",
+          hintMsgKey = "cf.historic.document.request.endDate.hint")
+      }
+
+      "fileRole is SecurityStatement" in {
+        val actual = DateMessages(SecurityStatement)
+
+        actual.startDate mustBe DateMessage(
+          labelMsgKey = "cf.historic.document.request.from",
+          hintMsgKey = "cf.historic.document.request.date.SecurityStatement.hint")
+
+        actual.endDate mustBe DateMessage(
+          labelMsgKey = "cf.historic.document.request.to",
+          hintMsgKey = "cf.historic.document.request.endDate.hint")
+      }
+
+      "fileRole is PostponedVATStatement" in {
+        val actual = DateMessages(PostponedVATStatement)
+
+        actual.startDate mustBe DateMessage(
+          labelMsgKey = "cf.historic.document.request.from",
+          hintMsgKey = "cf.historic.document.request.date.PostponedVATStatement.hint")
+
+        actual.endDate mustBe DateMessage(
+          labelMsgKey = "cf.historic.document.request.to",
+          hintMsgKey = "cf.historic.document.request.endDate.hint")
+      }
+    }
+  }
+}

--- a/test/views/HistoricDateRequestPageViewSpec.scala
+++ b/test/views/HistoricDateRequestPageViewSpec.scala
@@ -18,8 +18,10 @@ package views
 
 import base.SpecBase
 import forms.HistoricDateRequestPageFormProvider
-import models.{C79Certificate, DateMessages, DutyDefermentStatement, FileRole, HistoricDates, NormalMode,
-  PostponedVATStatement, SecurityStatement}
+import models.{
+  C79Certificate, DateMessages, DutyDefermentStatement, FileRole, HistoricDates, NormalMode,
+  PostponedVATStatement, SecurityStatement
+}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import play.api.Application

--- a/test/views/HistoricDateRequestPageViewSpec.scala
+++ b/test/views/HistoricDateRequestPageViewSpec.scala
@@ -18,7 +18,7 @@ package views
 
 import base.SpecBase
 import forms.HistoricDateRequestPageFormProvider
-import models.{FileRole, HistoricDates, NormalMode, SecurityStatement, PostponedVATStatement, DutyDefermentStatement, C79Certificate}
+import models.{C79Certificate, DateMessages, DutyDefermentStatement, FileRole, HistoricDates, NormalMode, PostponedVATStatement, SecurityStatement}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import play.api.Application
@@ -53,13 +53,13 @@ class HistoricDateRequestPageViewSpec extends SetUpWithSpecBase {
         }
 
         "statement start date text and hint text is displayed" in {
-          viewDoc.text().contains(msgs("cf.historic.document.request.from.statements")) mustBe true
-          viewDoc.getElementById("start-hint").text() mustBe msgs("cf.historic.document.request.date.pvat.hint")
+          viewDoc.text().contains(startDateText) mustBe true
+          viewDoc.getElementById("start-hint").text() mustBe startDateHint(fileRole)
         }
 
         "statement end date text and hint text is displayed" in {
-          viewDoc.text().contains(msgs("cf.historic.document.request.to.statements")) mustBe true
-          viewDoc.getElementById("end-hint").text() mustBe msgs("cf.historic.document.request.date.pvat.hint")
+          viewDoc.text().contains(endDateText) mustBe true
+          viewDoc.getElementById("end-hint").text() mustBe endDateHint
         }
 
         "start date check box month and year is displayed" in {
@@ -106,8 +106,24 @@ trait SetUpWithSpecBase extends SpecBase {
       NormalMode,
       fileRole,
       returnUrl,
+      DateMessages(fileRole),
       Some("accountNumber"),
       Some(false)
     ).body)
+
+  val startDateText: String = msgs("cf.historic.document.request.from")
+
+  protected def startDateHint(fileRole: FileRole): String = {
+    fileRole match {
+      case C79Certificate => msgs("cf.historic.document.request.date.C79Certificate.hint")
+      case PostponedVATStatement => msgs("cf.historic.document.request.date.PostponedVATStatement.hint")
+      case DutyDefermentStatement => msgs("cf.historic.document.request.date.DutyDefermentStatement.hint")
+      case SecurityStatement => msgs("cf.historic.document.request.date.SecurityStatement.hint")
+    }
+  }
+
+  val endDateText: String = msgs("cf.historic.document.request.to")
+
+  val endDateHint: String = msgs("cf.historic.document.request.endDate.hint")
 
 }

--- a/test/views/HistoricDateRequestPageViewSpec.scala
+++ b/test/views/HistoricDateRequestPageViewSpec.scala
@@ -18,7 +18,7 @@ package views
 
 import base.SpecBase
 import forms.HistoricDateRequestPageFormProvider
-import models.{HistoricDates, NormalMode, SecurityStatement}
+import models.{FileRole, HistoricDates, NormalMode, SecurityStatement, PostponedVATStatement, DutyDefermentStatement, C79Certificate}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import play.api.Application
@@ -28,89 +28,86 @@ import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import views.html.HistoricDateRequestPageView
 
-class HistoricDateRequestPageViewSpec extends SpecBase {
+class HistoricDateRequestPageViewSpec extends SetUpWithSpecBase {
 
   "view" should {
-    "display correct text" when {
-      "title is displayed" in new SetUp {
-        view.title() mustBe s"${
-          message(
-            "cf.historic.document.request.SecurityStatement.title")
-        } - ${message("service.name")} - GOV.UK"
 
-      }
+    fileRoles.foreach { fileRole =>
 
-      "date is displayed" in new SetUp {
-        view.getElementsByTag("h1").text() mustBe
-          message("cf.historic.document.request.heading.SecurityStatement")
-      }
+      s"display correct text for $fileRole" when {
+        val viewDoc = view(fileRole)
 
-      "sub header text is displayed" in new SetUp {
-        view.text().contains(
-          message("cf.historic.document.request.info-text.SecurityStatement")) mustBe true
+        "title is displayed" in {
+          viewDoc.title() mustBe s"${
+            msgs(s"cf.historic.document.request.$fileRole.title")
+          } - ${msgs("service.name")} - GOV.UK"
+        }
 
-      }
+        "date is displayed" in {
+          viewDoc.getElementsByTag("h1").text() mustBe
+            msgs(s"cf.historic.document.request.heading.$fileRole")
+        }
 
-      "statement start date text and hint text is displayed" in new SetUp {
-        view.text().contains(
-          message("cf.historic.document.request.from.statements")) mustBe true
+        "sub header text is displayed" in {
+          viewDoc.text().contains(msgs(s"cf.historic.document.request.info-text.$fileRole")) mustBe true
+        }
 
-        view.getElementById("start-hint").text() mustBe message(
-          "cf.historic.document.request.date.pvat.hint"
-        )
+        "statement start date text and hint text is displayed" in {
+          viewDoc.text().contains(msgs("cf.historic.document.request.from.statements")) mustBe true
+          viewDoc.getElementById("start-hint").text() mustBe msgs("cf.historic.document.request.date.pvat.hint")
+        }
 
-      }
+        "statement end date text and hint text is displayed" in {
+          viewDoc.text().contains(msgs("cf.historic.document.request.to.statements")) mustBe true
+          viewDoc.getElementById("end-hint").text() mustBe msgs("cf.historic.document.request.date.pvat.hint")
+        }
 
-      "statement end date text and hint text is displayed" in new SetUp {
-        view.text().contains(message("cf.historic.document.request.to.statements")) mustBe true
+        "start date check box month and year is displayed" in {
+          viewDoc.text().contains(msgs("date.month")) mustBe true
 
-        view.getElementById("end-hint").text() mustBe message(
-          "cf.historic.document.request.date.pvat.hint"
-        )
-      }
+          val startMonth: Element = viewDoc.getElementById("start.month")
+          Option(startMonth) must not be empty
 
-      "start date check box month and year is displayed" in new SetUp {
-        view.text().contains(message("date.month")) mustBe true
+          viewDoc.text().contains(msgs("date.year")) mustBe true
 
-        val startMonth: Element = view.getElementById("start.month")
-        Option(startMonth) must not be empty
+          val endMonth: Element = viewDoc.getElementById("start.year")
+          Option(endMonth) must not be empty
+        }
 
-        view.text().contains(message("date.year")) mustBe true
+        "display a back link" in {
+          viewDoc.getElementsByClass("govuk-back-link").attr("href") mustBe returnUrl
+        }
 
-        val endMonth: Element = view.getElementById("start.year")
-        Option(endMonth) must not be empty
-
-      }
-
-      "display a back link" in new SetUp {
-        view.getElementsByClass("govuk-back-link").attr("href") mustBe returnUrl
-      }
-
-      "display a continue button" in new SetUp {
-        view.getElementsByClass("govuk-button").html().contains(message(
-          "cf.historic.document.request.continue"
-        )) mustBe true
+        "display a continue button" in {
+          viewDoc.getElementsByClass("govuk-button")
+            .html()
+            .contains(msgs("cf.historic.document.request.continue")) mustBe true
+        }
       }
     }
   }
 
-  trait SetUp {
-    val app: Application = applicationBuilder().build()
-    val returnUrl = "http://localhost:9398/customs/documents/adjustments"
+}
 
-    implicit val message: Messages = messages(app)
-    implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()
+trait SetUpWithSpecBase extends SpecBase {
+  val app: Application = applicationBuilder().build()
+  val returnUrl = "http://localhost:9398/customs/documents/adjustments"
 
-    val form: Form[HistoricDates] = new HistoricDateRequestPageFormProvider().apply(SecurityStatement)
+  implicit val msgs: Messages = messages(app)
+  implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest()
 
-    val view: Document = Jsoup.parse(app.injector.instanceOf[HistoricDateRequestPageView].apply(
-      form,
+  private def form(fileRole: FileRole): Form[HistoricDates] = new HistoricDateRequestPageFormProvider().apply(fileRole)
+
+  val fileRoles: Seq[FileRole] = Seq(SecurityStatement, C79Certificate, PostponedVATStatement, DutyDefermentStatement)
+
+  protected def view(fileRole: FileRole): Document =
+    Jsoup.parse(app.injector.instanceOf[HistoricDateRequestPageView].apply(
+      form(fileRole),
       NormalMode,
-      SecurityStatement,
+      fileRole,
       returnUrl,
       Some("accountNumber"),
       Some(false)
     ).body)
-  }
 
 }

--- a/test/views/HistoricDateRequestPageViewSpec.scala
+++ b/test/views/HistoricDateRequestPageViewSpec.scala
@@ -18,7 +18,8 @@ package views
 
 import base.SpecBase
 import forms.HistoricDateRequestPageFormProvider
-import models.{C79Certificate, DateMessages, DutyDefermentStatement, FileRole, HistoricDates, NormalMode, PostponedVATStatement, SecurityStatement}
+import models.{C79Certificate, DateMessages, DutyDefermentStatement, FileRole, HistoricDates, NormalMode,
+  PostponedVATStatement, SecurityStatement}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import play.api.Application
@@ -123,7 +124,5 @@ trait SetUpWithSpecBase extends SpecBase {
   }
 
   val endDateText: String = msgs("cf.historic.document.request.to")
-
   val endDateHint: String = msgs("cf.historic.document.request.endDate.hint")
-
 }


### PR DESCRIPTION
Description - Code changes to update the date picker texts for different type of statements. This PR include changes for ticket no 4878, 4879 and 4879

Below has been done as part of this ticket

- add new model named DateMessages to capture the Date related msg keys
- add test cases
- add new message keys
- update existing message keys
- refactoring, remove the unnecessary duplication of inputDate fields

