### PR TITLE
MMCA-4917 | Implement CSV hyperlink to download on cash account transaction - V2

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -17,7 +17,7 @@
 package config
 
 import com.google.inject.{Inject, Singleton}
-import models.{C79Certificate, DutyDefermentStatement, FileRole, PostponedVATStatement, SecurityStatement, UserAnswers}
+import models._
 import pages.RequestedLinkId
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -57,10 +57,12 @@ class FrontendAppConfig @Inject()(configuration: Configuration, servicesConfig: 
   private lazy val c79ReturnLink: String = configuration.get[String]("urls.c79Return")
   private lazy val adjustmentsReturnLink: String = configuration.get[String]("urls.adjustmentsReturn")
   private lazy val postponedVatReturnLink: String = configuration.get[String]("urls.postponedVatReturn")
+  private lazy val cashStatementReturnLink: String = configuration.get[String]("urls.cashStatementReturn")
 
   lazy val sdesDutyDefermentStatementListUrl: String = sdesApi + "/files-available/list/DutyDefermentStatement"
   lazy val sdesImportVatCertificateListUrl: String = sdesApi + "/files-available/list/C79Certificate"
   lazy val sdesImportPostponedVatStatementListUrl: String = sdesApi + "/files-available/list/PostponedVATStatement"
+  lazy val sdesCashStatementListUrl: String = sdesApi + "/files-available/list/CashStatement"
 
   lazy val sdesSecurityStatementListUrl: String = sdesApi + "/files-available/list/SecurityStatement"
   lazy val historicDocumentsApiUrl: String = customsFinancialsApi + "/historic-document-request"
@@ -90,6 +92,7 @@ class FrontendAppConfig @Inject()(configuration: Configuration, servicesConfig: 
       case C79Certificate => c79ReturnLink
       case SecurityStatement => adjustmentsReturnLink
       case PostponedVATStatement => postponedVatReturnLink
+      case CashStatement => cashStatementReturnLink
     }
   }
 
@@ -99,6 +102,7 @@ class FrontendAppConfig @Inject()(configuration: Configuration, servicesConfig: 
       case C79Certificate => c79ReturnLink
       case SecurityStatement => adjustmentsReturnLink
       case PostponedVATStatement => postponedVatReturnLink
+      case CashStatement => cashStatementReturnLink
     }
   }
 

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -17,7 +17,15 @@
 package config
 
 import com.google.inject.{Inject, Singleton}
-import models._
+import models.{
+  C79Certificate,
+  CashStatement,
+  DutyDefermentStatement,
+  FileRole,
+  PostponedVATStatement,
+  SecurityStatement,
+  UserAnswers
+}
 import pages.RequestedLinkId
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -62,7 +70,7 @@ class FrontendAppConfig @Inject()(configuration: Configuration, servicesConfig: 
   lazy val sdesDutyDefermentStatementListUrl: String = sdesApi + "/files-available/list/DutyDefermentStatement"
   lazy val sdesImportVatCertificateListUrl: String = sdesApi + "/files-available/list/C79Certificate"
   lazy val sdesImportPostponedVatStatementListUrl: String = sdesApi + "/files-available/list/PostponedVATStatement"
-  lazy val sdesCashStatementListUrl: String = sdesApi + "/files-available/list/CashStatement"
+  lazy val sdesCashStatementListUrl: String = s"$sdesApi/files-available/list/CashStatement"
 
   lazy val sdesSecurityStatementListUrl: String = sdesApi + "/files-available/list/SecurityStatement"
   lazy val historicDocumentsApiUrl: String = customsFinancialsApi + "/historic-document-request"

--- a/app/connectors/SdesConnector.scala
+++ b/app/connectors/SdesConnector.scala
@@ -50,6 +50,12 @@ class SdesConnector @Inject()(http: HttpClientV2,
     getSdesFiles[FileInformation, VatCertificateFile](appConfig.sdesImportVatCertificateListUrl, eori, transform)
   }
 
+  def getCashStatements(eori: String)(implicit hc: HeaderCarrier): Future[Seq[CashStatementFile]] = {
+
+    val transform = convertTo[CashStatementFile] andThen filterFileFormats(SdesFileFormats)
+    getSdesFiles[FileInformation, CashStatementFile](appConfig.sdesCashStatementListUrl, eori, transform)
+  }
+
   def getPostponedVatStatements(eori: String)(implicit hc: HeaderCarrier): Future[Seq[PostponedVatStatementFile]] = {
 
     val transform = convertTo[PostponedVatStatementFile] andThen filterFileFormats(SdesFileFormats)

--- a/app/controllers/HistoricStatementsController.scala
+++ b/app/controllers/HistoricStatementsController.scala
@@ -39,7 +39,7 @@ class HistoricStatementsController @Inject()(identify: IdentifierAction,
                                              sessionCacheConnector: CustomsSessionCacheConnector,
                                              sdesConnector: SdesConnector,
                                              importVatView: ImportVatRequestedStatements,
-                                             importCashView: CashStatementView,
+                                             importCashStatementView: CashStatementView,
                                              importPostponedVatView: ImportPostponedVatRequestedStatements,
                                              securitiesView: SecuritiesRequestedStatements,
                                              sortStatementsService: SortStatementsService,
@@ -95,7 +95,7 @@ class HistoricStatementsController @Inject()(identify: IdentifierAction,
       })
 
       viewModel = CashStatementViewModel(allCertificates.sorted)
-    } yield Ok(importCashView(viewModel, appConfig.returnLink(CashStatement)))
+    } yield Ok(importCashStatementView(viewModel, appConfig.returnLink(CashStatement)))
   }
 
   private def showHistoricPostponedVatStatements()(

--- a/app/helpers/Formatters.scala
+++ b/app/helpers/Formatters.scala
@@ -35,6 +35,13 @@ trait DateFormatters {
     s"${dateAsMonth(date)}-${date.getYear}"
 
   def dateAsDay(date: LocalDate): String = DateTimeFormatter.ofPattern("d").format(date)
+
+  def dateAsMonthToMonth(periodStartMonth: Int, periodEndMonth: Int)(implicit messages: Messages): String = {
+    val startMonth = messages(s"month.$periodStartMonth")
+    val endMonth = messages(s"month.$periodEndMonth")
+
+    s"$startMonth to $endMonth"
+  }
 }
 
 trait FileFormatters {

--- a/app/helpers/Formatters.scala
+++ b/app/helpers/Formatters.scala
@@ -36,11 +36,11 @@ trait DateFormatters {
 
   def dateAsDay(date: LocalDate): String = DateTimeFormatter.ofPattern("d").format(date)
 
-  def dateAsMonthToMonth(periodStartMonth: Int, periodEndMonth: Int)(implicit messages: Messages): String = {
+  def periodAsStartToEndMonth(periodStartMonth: Int, periodEndMonth: Int)(implicit messages: Messages): String = {
     val startMonth = messages(s"month.$periodStartMonth")
     val endMonth = messages(s"month.$periodEndMonth")
 
-    s"$startMonth to $endMonth"
+    s"$startMonth ${messages("cf.cash-statement-requested-to")} $endMonth"
   }
 }
 

--- a/app/models/DateMessages.scala
+++ b/app/models/DateMessages.scala
@@ -25,6 +25,14 @@ object DateMessages {
   def apply(fileRole: FileRole): DateMessages = {
 
     fileRole match {
+      case CashStatement =>
+        DateMessages(
+          startDate =
+            DateMessage("cf.historic.document.request.from", "cf.historic.document.request.date.CashStatement.hint"),
+
+          endDate = DateMessage("cf.historic.document.request.to", "cf.historic.document.request.endDate.hint")
+        )
+
       case C79Certificate =>
         DateMessages(
           startDate =

--- a/app/models/FileRole.scala
+++ b/app/models/FileRole.scala
@@ -25,6 +25,7 @@ case object DutyDefermentStatement extends FileRole("DutyDefermentStatement")
 case object C79Certificate extends FileRole("C79Certificate")
 case object SecurityStatement extends FileRole("SecurityStatement")
 case object PostponedVATStatement extends FileRole("PostponedVATStatement")
+case object CashStatement extends FileRole("CashStatement")
 
 object FileRole {
   implicit val format: Format[FileRole] = new Format[FileRole] {
@@ -34,6 +35,7 @@ object FileRole {
         case JsString("C79Certificate") => JsSuccess(C79Certificate)
         case JsString("SecurityStatement") => JsSuccess(SecurityStatement)
         case JsString("PostponedVATStatement") => JsSuccess(PostponedVATStatement)
+        case JsString("CashStatement") => JsSuccess(CashStatement)
         case e => JsError(s"Invalid file role: $e")
       }
     }
@@ -47,6 +49,7 @@ object FileRole {
         case "duty-deferment" => Right(DutyDefermentStatement)
         case "adjustments" => Right(SecurityStatement)
         case "postponed-vat" => Right(PostponedVATStatement)
+        case "cash-statement" => Right(CashStatement)
         case fileRole => Left(s"unknown file role: $fileRole")
       }
     }
@@ -57,6 +60,7 @@ object FileRole {
         case DutyDefermentStatement => "duty-deferment"
         case SecurityStatement => "adjustments"
         case PostponedVATStatement => "postponed-vat"
+        case CashStatement => "cash-statement"
       }
     }
   }

--- a/app/services/SdesGatekeeperService.scala
+++ b/app/services/SdesGatekeeperService.scala
@@ -21,7 +21,6 @@ import models._
 import javax.inject.Singleton
 import scala.language.implicitConversions
 
-
 @Singleton
 class SdesGatekeeperService() {
 
@@ -37,6 +36,27 @@ class SdesGatekeeperService() {
         metadata("PeriodStartMonth").toInt,
         FileFormat(metadata("FileType")),
         mapFileRole(metadata("FileRole")),
+        metadata.get("statementRequestID"))
+    )
+  }
+
+  implicit def convertToCashStatementFile(sdesResponseFile: FileInformation): CashStatementFile = {
+    val metadata = sdesResponseFile.metadata.asMap
+
+    CashStatementFile(
+      sdesResponseFile.filename,
+      sdesResponseFile.downloadURL,
+      sdesResponseFile.fileSize,
+      CashStatementFileMetadata(
+        metadata("PeriodStartYear").toInt,
+        metadata("PeriodStartMonth").toInt,
+        metadata("PeriodStartDay").toInt,
+        metadata("PeriodEndYear").toInt,
+        metadata("PeriodEndMonth").toInt,
+        metadata("PeriodEndDay").toInt,
+        FileFormat(metadata("FileType")),
+        mapFileRole(metadata("FileRole")),
+        metadata.get("CashAccountNumber"),
         metadata.get("statementRequestID"))
     )
   }
@@ -115,6 +135,7 @@ class SdesGatekeeperService() {
       case "SecurityStatement" => SecurityStatement
       case "DutyDefermentStatement" => DutyDefermentStatement
       case "PostponedVATStatement" => PostponedVATStatement
+      case "CashStatement" => CashStatement
       case _ => throw new Exception(s"Unknown file role: $role")
     }
   }

--- a/app/services/SortStatementsService.scala
+++ b/app/services/SortStatementsService.scala
@@ -45,6 +45,24 @@ class SortStatementsService @Inject()() {
     SecurityStatementsForEori(historicEori, current, requested)
   }
 
+  def sortCashStatementsForEori(historicEori: EoriHistory, cashStatementFiles: Seq[CashStatementFile])
+                               (implicit messages: Messages): CashStatementForEori = {
+
+    val groupedByMonth = cashStatementFiles.groupBy(_.monthAndYear).map {
+      case (month, filesForMonth) => CashStatementByMonth(month, filesForMonth)
+    }.toList
+
+    val filteredByStatementRequestId = groupedByMonth.map { statementByMonth =>
+      val filteredFiles = statementByMonth.files.filter(_.metadata.statementRequestId.isDefined)
+
+      CashStatementByMonth(statementByMonth.date, filteredFiles)
+    }
+
+    val (requested, current) = filteredByStatementRequestId.partition(_.files.nonEmpty)
+
+    CashStatementForEori(historicEori, current, requested)
+  }
+
   def sortVatCertificatesForEori(historicEori: EoriHistory, vatCertificateFiles: Seq[VatCertificateFile])
                                 (implicit messages: Messages): VatCertificatesForEori = {
 

--- a/app/viewmodels/CashStatementViewModel.scala
+++ b/app/viewmodels/CashStatementViewModel.scala
@@ -38,7 +38,7 @@ case class CashStatementByMonth(date: LocalDate, files: Seq[CashStatementFile] =
                                (implicit messages: Messages) extends Ordered[CashStatementByMonth] {
 
   val formattedMonthToMonth: String = files.headOption.map { file =>
-    Formatters.dateAsMonthToMonth(file.metadata.periodStartMonth, file.metadata.periodEndMonth)
+    Formatters.periodAsStartToEndMonth(file.metadata.periodStartMonth, file.metadata.periodEndMonth)
   }.getOrElse(emptyString)
 
   val cashAccountNumber: Option[String] = files.headOption.flatMap(_.metadata.cashAccountNumber)

--- a/app/views/CashStatementView.scala.html
+++ b/app/views/CashStatementView.scala.html
@@ -27,7 +27,7 @@
 @statementsGroupedByYear = @{CashStatementViewModel.getRequestedStatementsGroupedByYear(viewModel)}
 @cashAccountHeading = @{CashStatementViewModel.generateCashAccountHeading(viewModel)}
 
-@layout(pageTitle = Some(messages("cf.cash-statement-requested-account-title")), backLinkUrl = Some(backLink)) {
+@layout(pageTitle = Some(messages("cf.cash-statement-requested-heading")), backLinkUrl = Some(backLink)) {
 
   @cashAccountHeading
 

--- a/app/views/CashStatementView.scala.html
+++ b/app/views/CashStatementView.scala.html
@@ -25,7 +25,7 @@
 @(viewModel: CashStatementViewModel, backLink: String)(implicit request: Request[_], messages: Messages)
 
 @statementsGroupedByYear = @{CashStatementViewModel.getRequestedStatementsGroupedByYear(viewModel)}
-@cashAccountHeading = @{CashStatementViewModel.generateCashAccountNumber(viewModel)}
+@cashAccountHeading = @{CashStatementViewModel.generateCashAccountHeading(viewModel)}
 
 @layout(pageTitle = Some(messages("cf.cash-statement-requested-account-title")), backLinkUrl = Some(backLink)) {
 

--- a/app/views/CashStatementView.scala.html
+++ b/app/views/CashStatementView.scala.html
@@ -1,0 +1,52 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.CashStatementViewModel
+@import views.html.templates.Layout
+@import models.FileFormat.Csv
+
+@this(layout: Layout,
+      h1: components.h1,
+      p: components.p)
+
+@(viewModel: CashStatementViewModel, backLink: String)(implicit request: Request[_], messages: Messages)
+
+@statementsGroupedByYear = @{CashStatementViewModel.getRequestedStatementsGroupedByYear(viewModel)}
+@cashAccountHeading = @{CashStatementViewModel.generateCashAccountNumber(viewModel)}
+
+@layout(pageTitle = Some(messages("cf.cash-statement-requested-account-title")), backLinkUrl = Some(backLink)) {
+
+  @cashAccountHeading
+
+  @h1(id = Some("requested-cash-statement-heading"),
+      classes = "govuk-heading-xl",
+      msg = messages("cf.cash-statement-requested-heading"))
+
+  @p(classes = "govuk-body",
+     id = Some("requested-cash-statement-paragraph"),
+     content = Html(messages("cf.cash-statement-requested-paragraph")))
+
+  @p(classes = "govuk-body",
+     id = Some("requested-cash-statement-list-paragraph"),
+     content = Html(messages("cf.cash-statement-requested-list-paragraph")))
+
+  @for(groupedStatements <- statementsGroupedByYear) {
+
+    @defining(CashStatementViewModel) { viewModel =>
+      @viewModel.generateStatementsByYear(groupedStatements)
+    }
+  }
+}

--- a/app/views/components/download_link_cash_account.scala.html
+++ b/app/views/components/download_link_cash_account.scala.html
@@ -1,0 +1,39 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(file: Option[CashStatementFile], fileFormat: FileFormat, id: String, period: String)(implicit messages: Messages)
+
+@if(file.isDefined) {
+    <a id="@id" class="file-link govuk-link" href="@{file.get.downloadURL}" download>
+        <span>@fileFormat (@file.get.formattedSize)</span>
+        <span class="govuk-visually-hidden">@voiceover(fileFormat, period, file.get.formattedSize)</span>
+    </a>
+} else {
+    <div id="missing-file-@id">
+        <span class="govuk-visually-hidden">@hiddentext(fileFormat, period)</span>
+        <span aria-hidden="true">@messages("cf.cash-statement-requested.missing-file")</span>
+    </div>
+}
+
+@hiddentext(fileFormat: FileFormat, period: String) = {
+    @messages("cf.cash-statement-requested.missing-file-hidden-text", fileFormat, period)
+}
+
+@voiceover(fileFormat: FileFormat, period: String, fileSize: String) = {
+    @messages("cf.cash-statement-requested.download-link", fileFormat, period, fileSize)
+}

--- a/app/views/components/download_link_cash_account.scala.html
+++ b/app/views/components/download_link_cash_account.scala.html
@@ -21,7 +21,7 @@
 @if(file.isDefined) {
     <a id="@id" class="file-link govuk-link" href="@{file.get.downloadURL}" download>
         <span>@fileFormat (@file.get.formattedSize)</span>
-        <span class="govuk-visually-hidden">@voiceover(fileFormat, period, file.get.formattedSize)</span>
+        <span class="govuk-visually-hidden" aria-hidden="true">@voiceover(fileFormat, period, file.get.formattedSize)</span>
     </a>
 } else {
     <div id="missing-file-@id">

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -115,6 +115,7 @@ urls {
   login         = "http://localhost:9553/bas-gateway/sign-in"
   loginContinue = "http://localhost:9876/customs/payment-records"
   c79Return = "http://localhost:9398/customs/documents/import-vat"
+  cashStatementReturn = "http://localhost:9394/customs/cash-account"
   postponedVatReturn = "http://localhost:9398/customs/documents/postponed-vat?location=CDS"
   adjustmentsReturn = "http://localhost:9398/customs/documents/adjustments"
   dutyDefermentReturn = "http://localhost:9397/customs/duty-deferment/"

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -201,7 +201,6 @@ cf.import-vat.requested.title=Tystysgrifau TAW mewnforio (C79) y gofynnwyd amdan
 cf.import-vat.requested.available.text=Mae tystysgrifau y gofynnwyd amdanynt ar gael i’w gweld am 10 diwrnod. Gallwn ddarparu’r rhain ar ffurf PDF yn unig.
 
 # Cash Requested Statements View
-cf.cash-statement-requested-account-title=
 cf.cash-statement-requested-account-heading=Cyfrif: {0}
 cf.cash-statement-requested-heading=Trafodion cyfrif arian parod
 cf.cash-statement-requested-paragraph=Mae’r trafodion y gwnaethoch gais amdanynt ar gael i’w lawrlwytho.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -90,6 +90,7 @@ cf.historic.document.request.whichStartDate.PostponedVATStatement=ar gyfer pa dd
 cf.historic.document.request.whichStartDate.SecurityStatement=ar gyfer pa ddyddiad dechrau y mae angen hysbysiad o ddatganiadau addasu arnoch?
 cf.historic.document.request.whichStartDate.DutyDefermentStatement=Ar gyfer pa ddyddiad dechrau y mae angen datganiadau gohirio tollau arnoch?
 cf.historic.document.request.date.C79Certificate.hint = Mae’n rhaid i’r dyddiad dechrau fod ar ôl Hydref 2019. Er enghraifft, 3 2021.
+cf.historic.document.request.date.CashStatement.hint = Mae’n rhaid i’r dyddiad dechrau fod ar ôl Hydref 2019. Er enghraifft, 3 2021.
 cf.historic.document.request.date.PostponedVATStatement.hint = Mae’n rhaid i’r dyddiad dechrau fod ar ôl Ionawr 2021. Er enghraifft, 3 2021.
 cf.historic.document.request.date.DutyDefermentStatement.hint = Mae’n rhaid i’r dyddiad dechrau fod ar ôl Ionawr 2021. Er enghraifft, 3 2021.
 cf.historic.document.request.date.SecurityStatement.hint = Mae’n rhaid i’r dyddiad dechrau fod ar ôl Hydref 2019. Er enghraifft, 3 2021.
@@ -198,6 +199,17 @@ cf.common.missing-documents-guidance.text2=Cynhyrchir {0} dim ond ar gyfer cyfno
 # Import VAT requested statements view
 cf.import-vat.requested.title=Tystysgrifau TAW mewnforio (C79) y gofynnwyd amdanynt
 cf.import-vat.requested.available.text=Mae tystysgrifau y gofynnwyd amdanynt ar gael i’w gweld am 10 diwrnod. Gallwn ddarparu’r rhain ar ffurf PDF yn unig.
+
+# Cash Requested Statements View
+cf.cash-statement-requested-account-title=
+cf.cash-statement-requested-account-heading=Cyfrif: {0}
+cf.cash-statement-requested-heading=Trafodion cyfrif arian parod
+cf.cash-statement-requested-paragraph=Mae’r trafodion y gwnaethoch gais amdanynt ar gael i’w lawrlwytho.
+cf.cash-statement-requested-list-paragraph=Crëwyd y rhestr hon ar 19 Awst 2024. Bydd ar gael i’w gweld am 10 diwrnod.
+
+cf.cash-statement-requested.download-link=Lawrlwytho {0} o {1} ({2})
+cf.cash-statement-requested.missing-file=Nid yw ar gael
+cf.cash-statement-requested.missing-file-hidden-text=Nid yw {0} ar gyfer {1} ar gael
 
 # Import Postponed VAT requested statements view
 cf.import-postponed-vat.requested.title=Y datganiadau ar gyfer TAW mewnforio ohiriedig y gofynnoch amdanynt

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -205,6 +205,7 @@ cf.cash-statement-requested-account-heading=Cyfrif: {0}
 cf.cash-statement-requested-heading=Trafodion cyfrif arian parod
 cf.cash-statement-requested-paragraph=Mae’r trafodion y gwnaethoch gais amdanynt ar gael i’w lawrlwytho.
 cf.cash-statement-requested-list-paragraph=Crëwyd y rhestr hon ar 19 Awst 2024. Bydd ar gael i’w gweld am 10 diwrnod.
+cf.cash-statement-requested-to=i
 
 cf.cash-statement-requested.download-link=Lawrlwytho {0} o {1} ({2})
 cf.cash-statement-requested.missing-file=Nid yw ar gael

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -90,6 +90,7 @@ cf.historic.document.request.whichStartDate.PostponedVATStatement=which start da
 cf.historic.document.request.whichStartDate.SecurityStatement=which start date do you need adjustment statements?
 cf.historic.document.request.whichStartDate.DutyDefermentStatement=which start date do you need deferment statements?
 cf.historic.document.request.date.C79Certificate.hint = Start date must be after October 2019. For example, 3 2021.
+cf.historic.document.request.date.CashStatement.hint = Start date must be after October 2019. For example, 3 2021.
 cf.historic.document.request.date.PostponedVATStatement.hint = Start date must be after January 2021. For example, 3 2021.
 cf.historic.document.request.date.DutyDefermentStatement.hint = Start date must be after September 2019. For example, 3 2021.
 cf.historic.document.request.date.SecurityStatement.hint = Start date must be after October 2019. For example, 3 2021.
@@ -195,6 +196,17 @@ cf.common.missing-documents-guidance.text2={0} are only generated for periods in
 # Import VAT requested statements view
 cf.import-vat.requested.title=Requested import VAT certificates (C79)
 cf.import-vat.requested.available.text=Requested certificates are available to view for 10 days. We can only provide these in PDF format.
+
+# Cash Requested Statements View
+cf.cash-statement-requested-account-title=Requested cash statements
+cf.cash-statement-requested-account-heading=Account: {0}
+cf.cash-statement-requested-heading=Cash account transactions
+cf.cash-statement-requested-paragraph=The transactions you requested are available to download.
+cf.cash-statement-requested-list-paragraph=This list was created on 19th August 2024. It will be available to view for 10 days.
+
+cf.cash-statement-requested.download-link=Download {0} of {1} ({2})
+cf.cash-statement-requested.missing-file=Unavailable
+cf.cash-statement-requested.missing-file-hidden-text={0} for {1} unavailable
 
 # Import Postponed VAT requested statements view
 cf.import-postponed-vat.requested.title=Your requested Postponed import VAT statements

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -198,7 +198,6 @@ cf.import-vat.requested.title=Requested import VAT certificates (C79)
 cf.import-vat.requested.available.text=Requested certificates are available to view for 10 days. We can only provide these in PDF format.
 
 # Cash Requested Statements View
-cf.cash-statement-requested-account-title=Requested cash statements
 cf.cash-statement-requested-account-heading=Account: {0}
 cf.cash-statement-requested-heading=Cash account transactions
 cf.cash-statement-requested-paragraph=The transactions you requested are available to download.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -202,6 +202,7 @@ cf.cash-statement-requested-account-heading=Account: {0}
 cf.cash-statement-requested-heading=Cash account transactions
 cf.cash-statement-requested-paragraph=The transactions you requested are available to download.
 cf.cash-statement-requested-list-paragraph=This list was created on 19th August 2024. It will be available to view for 10 days.
+cf.cash-statement-requested-to=to
 
 cf.cash-statement-requested.download-link=Download {0} of {1} ({2})
 cf.cash-statement-requested.missing-file=Unavailable

--- a/test/config/FrontendAppConfigSpec.scala
+++ b/test/config/FrontendAppConfigSpec.scala
@@ -17,7 +17,7 @@
 package config
 
 import base.SpecBase
-import models.{C79Certificate, DutyDefermentStatement, SecurityStatement}
+import models.{C79Certificate, CashStatement, DutyDefermentStatement, SecurityStatement}
 import org.scalatest.TryValues.convertTryToSuccessOrFailure
 import pages.RequestedLinkId
 import play.api.Application
@@ -33,6 +33,11 @@ class FrontendAppConfigSpec extends SpecBase {
     "return the adjustments link if a C79Certificate FileRole provided" in new Setup {
       config.returnLink(C79Certificate, emptyUserAnswers) mustBe
         "http://localhost:9398/customs/documents/import-vat"
+    }
+
+    "return the adjustments link if a CashStatement FileRole provided" in new Setup {
+      config.returnLink(CashStatement, emptyUserAnswers) mustBe
+        "http://localhost:9394/customs/cash-account"
     }
 
     "return the DutyDeferment link if a DutyDeferment FileRole provided and linkId in user answers" in new Setup {

--- a/test/connectors/SdesConnectorSpec.scala
+++ b/test/connectors/SdesConnectorSpec.scala
@@ -34,6 +34,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.{eq => eqTo}
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class SdesConnectorSpec extends SpecBase {
 
@@ -121,11 +122,8 @@ class SdesConnectorSpec extends SpecBase {
         when(mockHttp.get(eqTo(url"$sdesCashStatementsUrl"))(any()))
           .thenReturn(requestBuilder)
 
-        running(app) {
-          val result: Seq[CashStatementFile] = await(
-            sdesConnector.getCashStatements(someEori)(hc))
-
-          result must be(cashStatementFiles)
+        sdesConnector.getCashStatements(someEori)(hc).map {
+          cashStatements => cashStatements mustBe cashStatementFiles
         }
       }
     }

--- a/test/connectors/SdesConnectorSpec.scala
+++ b/test/connectors/SdesConnectorSpec.scala
@@ -110,6 +110,26 @@ class SdesConnectorSpec extends SpecBase {
       }
     }
 
+    "getCashStatements" should {
+      "return transformed cash statements" in new Setup {
+
+        when(requestBuilder.execute(any[HttpReads[HttpResponse]], any[ExecutionContext]))
+          .thenReturn(Future.successful(HttpResponse(Status.OK,
+            Json.toJson(cashStatementFilesSdesResponse).toString())))
+
+        when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
+        when(mockHttp.get(eqTo(url"$sdesCashStatementsUrl"))(any()))
+          .thenReturn(requestBuilder)
+
+        running(app) {
+          val result: Seq[CashStatementFile] = await(
+            sdesConnector.getCashStatements(someEori)(hc))
+
+          result must be(cashStatementFiles)
+        }
+      }
+    }
+
     "throw exception when file with unknown fileRole" in new Setup {
 
       when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
@@ -141,6 +161,36 @@ class SdesConnectorSpec extends SpecBase {
     val minute = 23
 
     val size = 111L
+
+    val sdesCashStatementsUrl =
+      "http://localhost:9754/customs-financials-sdes-stub/files-available/list/CashStatement"
+
+    val cashStatementFilesSdesResponse: Seq[FileInformation] = List(
+      FileInformation("cash_statement_01", "download_url_01", size, Metadata(List(
+        MetadataItem("PeriodStartYear", "2018"), MetadataItem("PeriodStartMonth", "3"),
+        MetadataItem("PeriodStartDay", "14"), MetadataItem("PeriodEndYear", "2018"),
+        MetadataItem("PeriodEndMonth", "3"), MetadataItem("PeriodEndDay", "31"),
+        MetadataItem("FileType", "PDF"), MetadataItem("FileRole", "CashStatement")))),
+
+      FileInformation("cash_statement_02", "download_url_02", size, Metadata(List(
+        MetadataItem("PeriodStartYear", "2018"), MetadataItem("PeriodStartMonth", "2"),
+        MetadataItem("PeriodStartDay", "14"), MetadataItem("PeriodEndYear", "2018"),
+        MetadataItem("PeriodEndMonth", "2"), MetadataItem("PeriodEndDay", "28"),
+        MetadataItem("FileType", "PDF"), MetadataItem("FileRole", "CashStatement")))))
+
+    val cashStatementFiles: Seq[CashStatementFile] = List(
+      CashStatementFile("cash_statement_01", "download_url_01", size, CashStatementFileMetadata(
+        year, month, day, year, month, day + 17, Pdf, CashStatement, None)),
+
+      CashStatementFile("cash_statement_02", "download_url_02", size, CashStatementFileMetadata(
+        year, month - 1, day, year, month - 1, day + 14, Pdf, CashStatement, None)))
+
+    val cashStatementFilesWithUnknownFileRoleSdesResponse: Seq[FileInformation] = List(
+      FileInformation("cash_statement_01", "download_url_01", size, Metadata(List(
+        MetadataItem("PeriodStartYear", "2018"), MetadataItem("PeriodStartMonth", "3"),
+        MetadataItem("PeriodStartDay", "14"), MetadataItem("PeriodEndYear", "2018"),
+        MetadataItem("PeriodEndMonth", "3"), MetadataItem("PeriodEndDay", "31"),
+        MetadataItem("FileType", "PDF"), MetadataItem("FileRole", "Invalid"))))) ++ cashStatementFilesSdesResponse
 
     val sdesDutyDefermentStatementsUrl =
       "http://localhost:9754/customs-financials-sdes-stub/files-available/list/DutyDefermentStatement"

--- a/test/controllers/HistoricStatementsControllerSpec.scala
+++ b/test/controllers/HistoricStatementsControllerSpec.scala
@@ -22,12 +22,12 @@ import models.DDStatementType.{Excise, Supplementary, Weekly}
 import models.FileFormat.Pdf
 import models._
 import play.api.i18n.Messages
-import play.api.test.Helpers
+import play.api.test.{FakeRequest, Helpers}
 import play.api.test.Helpers._
 import play.api.{Application, inject}
-
 import org.mockito.Mockito.when
 import org.mockito.ArgumentMatchers.any
+import play.api.mvc.AnyContentAsEmpty
 
 import java.time._
 import scala.concurrent.Future
@@ -54,6 +54,19 @@ class HistoricStatementsControllerSpec extends SpecBase {
 
       val request = fakeRequest(GET,
         controllers.routes.HistoricStatementsController.historicStatements(C79Certificate).url)
+
+      running(app) {
+        val result = route(app, request).value
+        status(result) mustBe OK
+      }
+    }
+
+    "return Cash Statement" in new Setup {
+      when(mockSdesConnector.getCashStatements(any)(any))
+        .thenReturn(Future.successful(cashStatementFiles))
+
+      val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest(GET,
+        controllers.routes.HistoricStatementsController.historicStatements(CashStatement).url)
 
       running(app) {
         val result = route(app, request).value
@@ -150,6 +163,8 @@ class HistoricStatementsControllerSpec extends SpecBase {
     val fiveHundread = 500L
     val ninetynine = 99L
 
+    val size = 1024L
+
     val securityStatementFile = SecurityStatementFile("statementfile_00", "download_url_00", ninetynine,
       SecurityStatementFileMetadata(year17, twelve, twentyEight, year, one, one, Pdf,
         SecurityStatement, someEori, fiveHundread, "0000000"))
@@ -172,7 +187,19 @@ class HistoricStatementsControllerSpec extends SpecBase {
       PostponedVatStatementFileMetadata(year17, eleven, Pdf, PostponedVATStatement, "Chief", Some("a request id")))
     val postponedVatStatementFiles = Seq(postponedVatStatement, postponedVatStatement_2)
 
-    val size = 1024L
+    val cashStatementFile: CashStatementFile = CashStatementFile(
+      "statementfile_01",
+      "download_url_01",
+      size,
+      CashStatementFileMetadata(year, one, one, year, one, one, Pdf, CashStatement, None))
+
+    val cashStatementFiles: Seq[CashStatementFile] = Seq(
+      cashStatementFile,
+      CashStatementFile(
+        "statementfile_02",
+        "download_url_02",
+        size,
+        CashStatementFileMetadata(year, one, one, year, one, one, Pdf, CashStatement, None)))
 
     val dutyDeferementFile: DutyDefermentStatementFile = DutyDefermentStatementFile(
       "2018_03_01-08.pdf", "url.pdf", size,

--- a/test/controllers/HistoricStatementsControllerSpec.scala
+++ b/test/controllers/HistoricStatementsControllerSpec.scala
@@ -61,7 +61,7 @@ class HistoricStatementsControllerSpec extends SpecBase {
       }
     }
 
-    "return Cash Statement" in new Setup {
+    "return Cash Statements" in new Setup {
       when(mockSdesConnector.getCashStatements(any)(any))
         .thenReturn(Future.successful(cashStatementFiles))
 

--- a/test/helpers/FormattersSpec.scala
+++ b/test/helpers/FormattersSpec.scala
@@ -17,7 +17,9 @@
 package helpers
 
 import base.SpecBase
-import helpers.Formatters.fileSize
+import helpers.Formatters.{dateAsMonthToMonth, fileSize}
+import play.api.Application
+import play.api.i18n.Messages
 
 class FormattersSpec extends SpecBase {
 
@@ -57,13 +59,26 @@ class FormattersSpec extends SpecBase {
       res mustBe "2.0MB"
     }
 
+    "display 'January to March' when given periodStartMonth and periodEndMonth" in new Setup {
+      private val res = dateAsMonthToMonth(january, march)(msg)
+
+      res mustBe "January to March"
+    }
+
     trait Setup {
+
+      val app: Application = applicationBuilder().build()
+      implicit val msg: Messages = messages(app)
+
       val belowKbThreshold = 100
       val kbValue = 30567
       val mbValue = 20567567
 
       val kbThreshold = 1024
       val mbThreshold: Int = 1024 * 1024
+
+      val january = 1
+      val march = 3
     }
   }
 }

--- a/test/helpers/FormattersSpec.scala
+++ b/test/helpers/FormattersSpec.scala
@@ -17,7 +17,7 @@
 package helpers
 
 import base.SpecBase
-import helpers.Formatters.{dateAsMonthToMonth, fileSize}
+import helpers.Formatters.{fileSize, periodAsStartToEndMonth}
 import play.api.Application
 import play.api.i18n.Messages
 
@@ -60,7 +60,7 @@ class FormattersSpec extends SpecBase {
     }
 
     "display 'January to March' when given periodStartMonth and periodEndMonth" in new Setup {
-      private val res = dateAsMonthToMonth(january, march)(msg)
+      private val res = periodAsStartToEndMonth(january, march)(msg)
 
       res mustBe "January to March"
     }

--- a/test/models/DateMessagesSpec.scala
+++ b/test/models/DateMessagesSpec.scala
@@ -48,6 +48,18 @@ class DateMessagesSpec extends SpecBase {
           hintMsgKey = "cf.historic.document.request.endDate.hint")
       }
 
+      "fileRole is CashStatement" in {
+        val actual = DateMessages(CashStatement)
+
+        actual.startDate mustBe DateMessage(
+          labelMsgKey = "cf.historic.document.request.from",
+          hintMsgKey = "cf.historic.document.request.date.CashStatement.hint")
+
+        actual.endDate mustBe DateMessage(
+          labelMsgKey = "cf.historic.document.request.to",
+          hintMsgKey = "cf.historic.document.request.endDate.hint")
+      }
+
       "fileRole is SecurityStatement" in {
         val actual = DateMessages(SecurityStatement)
 

--- a/test/models/FileRoleSpec.scala
+++ b/test/models/FileRoleSpec.scala
@@ -25,15 +25,23 @@ class FileRoleSpec extends SpecBase {
     "return a JsSuccess for DutyDeferment" in {
       JsString("DutyDefermentStatement").as[FileRole] mustBe DutyDefermentStatement
     }
+
     "return a JsSuccess for C79Certificate" in {
       JsString("C79Certificate").as[FileRole] mustBe C79Certificate
     }
+
     "return a JsSuccess for SecurityStatement" in {
       JsString("SecurityStatement").as[FileRole] mustBe SecurityStatement
     }
+
     "return a JsSuccess for PostponedVATStatement" in {
       JsString("PostponedVATStatement").as[FileRole] mustBe PostponedVATStatement
     }
+
+    "return a JsSuccess for CashStatement" in {
+      JsString("CashStatement").as[FileRole] mustBe CashStatement
+    }
+
     "return exception for unknown file role" in {
       intercept[JsResultException] {
         JsString("Unknown").as[FileRole]

--- a/test/models/SdesFileSpec.scala
+++ b/test/models/SdesFileSpec.scala
@@ -17,10 +17,10 @@
 package models
 
 import base.SpecBase
-import models.DDStatementType._
-import models.FileFormat.{Pdf, UnknownFileFormat}
+import models.DDStatementType.*
+import models.FileFormat.{Csv, Pdf, UnknownFileFormat}
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.{JsString, Json}
 
 class SdesFileSpec extends SpecBase with Matchers {
@@ -34,6 +34,7 @@ class SdesFileSpec extends SpecBase with Matchers {
 
       securityStatementFile2 compare securityStatementFile1 mustBe one
       vatCertificateFile1 compare vatCertificateFile2 mustBe zero
+      cashStatementFile1 compare cashStatementFile2 mustBe zero
       postponedVatStatementFile1 compare postponedVatStatementFile2 mustBe zero
 
       FileFormat.unapply(Pdf).value mustBe "PDF"
@@ -101,6 +102,40 @@ class SdesFileSpec extends SpecBase with Matchers {
 
     val vatCertificateFile2 = VatCertificateFile("file1", "/download", size,
       VatCertificateFileMetadata(year3, size, Pdf, C79Certificate, None), "123456789")
+
+    val cashStatementFile1: CashStatementFile = CashStatementFile(
+      "file1",
+      "/download",
+      size,
+      CashStatementFileMetadata(
+        periodStartYear = year,
+        periodStartMonth = month,
+        periodStartDay = day,
+        periodEndYear = year,
+        periodEndMonth = month,
+        periodEndDay = day,
+        fileFormat = Csv,
+        fileRole = CashStatement,
+        cashAccountNumber = None,
+        statementRequestId = None
+      ), "123456789")
+
+    val cashStatementFile2: CashStatementFile = CashStatementFile(
+      "file2",
+      "/download",
+      size,
+      CashStatementFileMetadata(
+        periodStartYear = year,
+        periodStartMonth = month,
+        periodStartDay = day,
+        periodEndYear = year,
+        periodEndMonth = month,
+        periodEndDay = day,
+        fileFormat = Csv,
+        fileRole = CashStatement,
+        cashAccountNumber = None,
+        statementRequestId = None
+      ), "123456789")
 
     val postponedVatStatementFile1 = PostponedVatStatementFile("file1", "/download", size,
       PostponedVatStatementFileMetadata(year3, size, Pdf, PostponedVATStatement,

--- a/test/services/SortStatementsServiceSpec.scala
+++ b/test/services/SortStatementsServiceSpec.scala
@@ -18,7 +18,7 @@ package services
 
 import base.SpecBase
 import models.DDStatementType.{Excise, Weekly}
-import models.FileFormat.Pdf
+import models.FileFormat.{Csv, Pdf}
 import models._
 import play.api.i18n.Messages
 import play.api.test.Helpers
@@ -35,6 +35,13 @@ class SortStatementsServiceSpec extends SpecBase {
         sortStatementsService.sortSecurityCertificatesForEori(eoriHistory, securityStatementFiles)
 
       securityStatementsForEori.requestedStatements mustBe requestedSecurityStatements
+    }
+
+    "return requested cash statements for EORI" in new Setup {
+      val cashStatementsForEori: CashStatementForEori =
+        sortStatementsService.sortCashStatementsForEori(eoriHistory, cashStatementFiles)
+
+      cashStatementsForEori.requestedStatements mustBe requestedCashStatements
     }
 
     "return requested c79 certificates for EORI" in new Setup {
@@ -74,6 +81,69 @@ class SortStatementsServiceSpec extends SpecBase {
     val periodEndDay = 8
     val fileSize = 500L
     val size = 99L
+    val someAccountNumber: Option[String] = Some("123456789")
+
+    val cashStatementFilePdf: CashStatementFile = CashStatementFile(
+      "file1",
+      "/download1",
+      size,
+      CashStatementFileMetadata(
+        periodStartYear,
+        periodStartMonth,
+        periodStartDay,
+        periodEndYear,
+        periodEndMonth,
+        periodEndDay,
+        Pdf,
+        CashStatement,
+        someAccountNumber,
+        someRequestId
+      ), someEori)
+
+    val cashStatementFileCsv: CashStatementFile = CashStatementFile(
+      "file2",
+      "/download2",
+      size,
+      CashStatementFileMetadata(
+        periodStartYear,
+        periodStartMonth,
+        periodStartDay,
+        periodEndYear,
+        periodEndMonth,
+        periodEndDay,
+        Csv,
+        CashStatement,
+        someAccountNumber,
+        someRequestId
+      ), someEori)
+
+    val cashStatementFilePdf_2: CashStatementFile = CashStatementFile(
+      "file3",
+      "/download3",
+      size,
+      CashStatementFileMetadata(
+        periodStartYear - 1,
+        periodStartMonth,
+        periodStartDay,
+        periodEndYear - 1,
+        periodEndMonth,
+        periodEndDay,
+        Pdf,
+        CashStatement,
+        someAccountNumber,
+        someRequestId
+      ), someEori)
+
+    val requestedCashStatements: Seq[CashStatementByMonth] = List(
+      CashStatementByMonth(
+        LocalDate.of(periodStartYear - 1, periodStartMonth, periodStartDay),
+        Seq(cashStatementFilePdf_2)),
+      CashStatementByMonth(
+        LocalDate.of(periodStartYear, periodStartMonth, periodStartDay),
+        Seq(cashStatementFilePdf, cashStatementFileCsv)))
+
+    val cashStatementFiles: Seq[CashStatementFile] =
+      Seq(cashStatementFilePdf, cashStatementFileCsv, cashStatementFilePdf_2)
 
     val securityStatementFile: SecurityStatementFile = SecurityStatementFile("statementfile_00", "download_url_00",
       size, SecurityStatementFileMetadata(periodStartYear, periodStartMonth, periodStartDay, periodEndYear,

--- a/test/viewmodels/CashStatementViewModelSpec.scala
+++ b/test/viewmodels/CashStatementViewModelSpec.scala
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels
+
+import base.SpecBase
+import models.FileFormat.{Csv, Pdf}
+import models.*
+import play.api.Application
+import play.api.i18n.Messages
+import play.twirl.api.{Html, HtmlFormat}
+import utils.Utils.h2Component
+
+import java.time.LocalDate
+
+class CashStatementViewModelSpec extends SpecBase {
+
+  "getRequestedStatementsGroupedByYear" should {
+
+    "return grouped statements by year when exist" in new Setup {
+      val cashStatements: Seq[CashStatementForEori] = Seq(
+        CashStatementForEori(
+          eoriHistory = EoriHistory(eoriNumber, Some(startDateJuly), Some(endDateJuly)),
+          currentStatements = Seq.empty,
+          requestedStatements = Seq(CashStatementByMonth(startDateJuly))))
+
+      val viewModel: CashStatementViewModel =
+        CashStatementViewModel(statementsForAllEoris = cashStatements)
+
+      val result: Seq[GroupedStatementsByEori] = CashStatementViewModel.getRequestedStatementsGroupedByYear(viewModel)
+
+      result.size mustBe 1
+      result.head.statementsByYear.size mustBe 1
+      result.head.statementsByYear.head._1 mustBe periodStartYear
+      result.head.statementsByYear.head._2.head.formattedMonthYear mustBe s"$monthJuly $periodStartYear"
+    }
+
+    "return an empty sequence when no requested statements exist" in new Setup {
+      val cashStatements: Seq[CashStatementForEori] = Seq(
+        CashStatementForEori(
+          eoriHistory = EoriHistory(eoriNumber, Some(startDateJuly), Some(endDateJuly)),
+          currentStatements = Seq(CashStatementByMonth(startDateJuly)),
+          requestedStatements = Seq.empty))
+
+      val viewModel: CashStatementViewModel =
+        CashStatementViewModel(statementsForAllEoris = cashStatements)
+
+      val result: Seq[GroupedStatementsByEori] = CashStatementViewModel.getRequestedStatementsGroupedByYear(viewModel)
+
+      result mustBe empty
+    }
+  }
+
+  "hasRequestedStatements" should {
+
+    "return true if there are requested statements" in new Setup {
+      val cashStatements: Seq[CashStatementForEori] = Seq(
+        CashStatementForEori(
+          eoriHistory = EoriHistory(eoriNumber, Some(startDateJuly), Some(endDateJuly)),
+          currentStatements = Seq.empty,
+          requestedStatements = Seq(CashStatementByMonth(startDateJuly))
+        )
+      )
+
+      val viewModel: CashStatementViewModel =
+        CashStatementViewModel(statementsForAllEoris = cashStatements)
+
+      val result: Boolean = viewModel.statementsForAllEoris.exists(_.requestedStatements.nonEmpty)
+
+      result mustBe true
+    }
+
+    "return false if there are no requested statements" in new Setup {
+      val cashStatements: Seq[CashStatementForEori] = Seq(
+        CashStatementForEori(
+          eoriHistory = EoriHistory(eoriNumber, Some(startDateJuly), Some(endDateJuly)),
+          currentStatements = Seq.empty,
+          requestedStatements = Seq.empty))
+
+      val viewModel: CashStatementViewModel =
+        CashStatementViewModel(statementsForAllEoris = cashStatements)
+
+      val result: Boolean = viewModel.statementsForAllEoris.exists(_.requestedStatements.nonEmpty)
+
+      result mustBe false
+    }
+  }
+
+  "generateStatementsByYear" should {
+
+    "generate HTML correctly for statements" in new Setup {
+      val statements: Seq[CashStatementByMonth] = Seq(CashStatementByMonth(startDateJuly))
+      val groupedStatements: GroupedStatementsByEori = GroupedStatementsByEori(
+        eoriIndex = 0,
+        eoriHistory = EoriHistory(eoriNumber, Some(startDateJuly), Some(endDateJuly)),
+        statementsByYear = Map(periodStartYear -> statements))
+
+      val result: Html = CashStatementViewModel.generateStatementsByYear(groupedStatements)
+
+      val expectedYearHeading: HtmlFormat.Appendable = h2Component(
+        msg = periodStartYear.toString,
+        classes = "govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-7")
+
+      result.body must include(expectedYearHeading.body)
+    }
+
+    "generate HTML correctly for statement rows" in new Setup {
+      val statements: Seq[CashStatementByMonth] = Seq(
+        CashStatementByMonth(startDateJuly, Seq(csvFile)),
+        CashStatementByMonth(startDateJuly.plusMonths(1), Seq(pdfFile)))
+
+      val groupedStatements: GroupedStatementsByEori = GroupedStatementsByEori(
+        eoriIndex = 0,
+        eoriHistory = EoriHistory(eoriNumber, Some(startDateJuly), Some(endDateJuly)),
+        statementsByYear = Map(periodStartYear -> statements))
+
+      val result: Html = CashStatementViewModel.generateStatementsByYear(groupedStatements)
+
+      result.body must include(monthJuly)
+      result.body must include(monthAugust)
+      result.body must include("file.csv")
+      result.body must include("file.pdf")
+      result.body must include("Download PDF")
+      result.body must include("Download CSV")
+    }
+
+    "generate HTML correctly for multiple years in the grouped statements" in new Setup {
+      val statements2023: Seq[CashStatementByMonth] = Seq(CashStatementByMonth(startDateJuly))
+      val statements2024: Seq[CashStatementByMonth] = Seq(CashStatementByMonth(startDateJuly.plusYears(1)))
+      val groupedStatements: GroupedStatementsByEori = GroupedStatementsByEori(
+        eoriIndex = 0,
+        eoriHistory = EoriHistory(eoriNumber, Some(startDateJuly), Some(endDateJuly)),
+        statementsByYear = Map(
+          periodStartYear -> statements2023,
+          periodStartYear + 1 -> statements2024
+        )
+      )
+
+      val result: Html = CashStatementViewModel.generateStatementsByYear(groupedStatements)
+
+      result.body must include(periodStartYear.toString)
+      result.body must include((periodStartYear + 1).toString)
+
+      result.body must include(monthJuly)
+    }
+  }
+
+  trait Setup {
+
+    val app: Application = applicationBuilder().build()
+    implicit val msg: Messages = messages(app)
+
+    val eoriNumber = "EORI456"
+    val startDateJuly: LocalDate = LocalDate.parse("2023-07-10")
+    val endDateJuly: LocalDate = LocalDate.parse("2023-07-20")
+    val startDateJune: LocalDate = LocalDate.parse("2023-06-01")
+    val endDateJune: LocalDate = LocalDate.parse("2023-06-30")
+
+    val accountNumber: Option[String] = Some("123456789")
+    val monthJuly = "July"
+    val monthAugust = "August"
+
+    val periodStartYear = 2023
+    val periodStartMonth = 7
+    val periodStartDay = 1
+
+    val periodEndYear = 2023
+    val periodEndMonth = 8
+    val periodEndDay = 31
+
+    val expectedFileSizeCsv = 1048576L
+    val expectedFileSizePdf = 2097152L
+
+    val csvFileMetadata: CashStatementFileMetadata = CashStatementFileMetadata(
+      periodStartYear = periodStartYear,
+      periodStartMonth = periodStartMonth,
+      periodStartDay = periodStartDay,
+      periodEndYear = periodEndYear,
+      periodEndMonth = periodEndMonth - 1,
+      periodEndDay = periodEndDay,
+      fileFormat = Csv,
+      fileRole = CashStatement,
+      cashAccountNumber = accountNumber,
+      statementRequestId = None)
+
+    val pdfFileMetadata: CashStatementFileMetadata = CashStatementFileMetadata(
+      periodStartYear = periodStartYear,
+      periodStartMonth = periodStartMonth + 1,
+      periodStartDay = periodStartDay,
+      periodEndYear = periodEndYear,
+      periodEndMonth = periodEndMonth,
+      periodEndDay = periodEndDay,
+      fileFormat = Pdf,
+      fileRole = CashStatement,
+      cashAccountNumber = accountNumber,
+      statementRequestId = None)
+
+    val csvFile: CashStatementFile = CashStatementFile(
+      filename = "file.csv",
+      downloadURL = "file.csv",
+      size = expectedFileSizeCsv,
+      metadata = csvFileMetadata)
+
+    val pdfFile: CashStatementFile = CashStatementFile(
+      filename = "file.pdf",
+      downloadURL = "file.pdf",
+      size = expectedFileSizePdf,
+      metadata = pdfFileMetadata)
+  }
+}

--- a/test/viewmodels/CashStatementViewModelSpec.scala
+++ b/test/viewmodels/CashStatementViewModelSpec.scala
@@ -153,8 +153,6 @@ class CashStatementViewModelSpec extends SpecBase {
 
       result.body must include(periodStartYear.toString)
       result.body must include((periodStartYear + 1).toString)
-
-      result.body must include(monthJuly)
     }
   }
 

--- a/test/views/CashStatementViewSpec.scala
+++ b/test/views/CashStatementViewSpec.scala
@@ -29,7 +29,7 @@ import java.time.LocalDate
 class CashStatementViewSpec extends ViewTestHelper {
 
   "view" should {
-    
+
     "display correct title and contents" in new Setup {
       titleShouldBeCorrect(view, "cf.cash-statement-requested-heading")
       pageShouldContainBackLinkUrl(view, config.returnLink(CashStatement))

--- a/test/views/CashStatementViewSpec.scala
+++ b/test/views/CashStatementViewSpec.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import models.FileFormat.Csv
+import models.{CashStatement, CashStatementFile, CashStatementFileMetadata, EoriHistory}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.scalatest.Assertion
+import viewmodels.{CashStatementByMonth, CashStatementForEori, CashStatementViewModel}
+import views.html.CashStatementView
+
+import java.time.LocalDate
+
+class CashStatementViewSpec extends ViewTestHelper {
+
+  "view" should {
+    
+    "display correct title and contents" in new Setup {
+      titleShouldBeCorrect(view, "cf.cash-statement-requested-account-title")
+      pageShouldContainBackLinkUrl(view, config.returnLink(CashStatement))
+      headingShouldBeCorrect
+      requestedParagraphTextShouldBeCorrect
+      requestedListParagraphTextShouldBeCorrect
+    }
+  }
+
+  private def headingShouldBeCorrect(implicit view: Document): Assertion = {
+    view.getElementById("requested-cash-statement-heading")
+      .html()
+      .contains(msg("cf.cash-statement-requested-heading")) mustBe true
+  }
+
+  private def requestedParagraphTextShouldBeCorrect(implicit view: Document): Assertion = {
+    view.getElementById("requested-cash-statement-paragraph")
+      .html()
+      .contains(msg("cf.cash-statement-requested-paragraph")) mustBe true
+  }
+
+  private def requestedListParagraphTextShouldBeCorrect(implicit view: Document): Assertion = {
+    view.getElementById("requested-cash-statement-list-paragraph")
+      .html()
+      .contains(msg("cf.cash-statement-requested-list-paragraph")) mustBe true
+  }
+
+  trait Setup {
+
+    val someEori = "12345678"
+    val localDateYear = 2020
+    val localDateMonth = 10
+    val localDateDay = 1
+    val filename: String = "statement_file_01"
+    val downloadURL: String = "download_url_01"
+    val size = 120L
+    val periodStartYear: Int = 2019
+    val periodStartMonth: Int = 7
+    val periodStartDay: Int = 10
+
+    val eoriHistory: EoriHistory = EoriHistory(someEori,
+      Some(LocalDate.of(localDateYear, localDateMonth, localDateDay)),
+      Some(LocalDate.of(localDateYear, localDateMonth, localDateDay)))
+
+    val cashStatementFile: CashStatementFile = CashStatementFile(
+      filename,
+      downloadURL,
+      size,
+      CashStatementFileMetadata(
+        periodStartYear,
+        periodStartMonth,
+        periodStartDay,
+        periodStartYear,
+        periodStartMonth,
+        periodStartDay,
+        Csv,
+        CashStatement,
+        Some("requestId")
+      ), someEori)
+
+    val cashStatementsByMonth: CashStatementByMonth = CashStatementByMonth(
+      LocalDate.of(localDateYear, localDateMonth, localDateDay),
+      Seq(cashStatementFile))
+
+    val cashStatementsForEori: CashStatementForEori = CashStatementForEori(
+      eoriHistory,
+      Seq(cashStatementsByMonth),
+      Seq.empty)
+
+    val accountNumber = "12345"
+
+    val cashStatementViewModel: CashStatementViewModel = CashStatementViewModel(Seq(cashStatementsForEori))
+
+    implicit val view: Document = Jsoup.parse(app.injector.instanceOf[CashStatementView].apply(
+      cashStatementViewModel,
+      config.returnLink(CashStatement)).body)
+  }
+}

--- a/test/views/CashStatementViewSpec.scala
+++ b/test/views/CashStatementViewSpec.scala
@@ -31,7 +31,7 @@ class CashStatementViewSpec extends ViewTestHelper {
   "view" should {
     
     "display correct title and contents" in new Setup {
-      titleShouldBeCorrect(view, "cf.cash-statement-requested-account-title")
+      titleShouldBeCorrect(view, "cf.cash-statement-requested-heading")
       pageShouldContainBackLinkUrl(view, config.returnLink(CashStatement))
       headingShouldBeCorrect
       requestedParagraphTextShouldBeCorrect

--- a/test/views/HistoricDateRequestPageViewSpec.scala
+++ b/test/views/HistoricDateRequestPageViewSpec.scala
@@ -18,10 +18,7 @@ package views
 
 import base.SpecBase
 import forms.HistoricDateRequestPageFormProvider
-import models.{
-  C79Certificate, DateMessages, DutyDefermentStatement, FileRole, HistoricDates, NormalMode,
-  PostponedVATStatement, SecurityStatement
-}
+import models.{C79Certificate, CashStatement, DateMessages, DutyDefermentStatement, FileRole, HistoricDates, NormalMode, PostponedVATStatement, SecurityStatement}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import play.api.Application
@@ -122,6 +119,7 @@ trait SetUpWithSpecBase extends SpecBase {
       case PostponedVATStatement => msgs("cf.historic.document.request.date.PostponedVATStatement.hint")
       case DutyDefermentStatement => msgs("cf.historic.document.request.date.DutyDefermentStatement.hint")
       case SecurityStatement => msgs("cf.historic.document.request.date.SecurityStatement.hint")
+      case CashStatement => msgs("cf.historic.document.request.date.CashStatement.hint")
     }
   }
 

--- a/test/views/HistoricDateRequestPageViewSpec.scala
+++ b/test/views/HistoricDateRequestPageViewSpec.scala
@@ -18,7 +18,17 @@ package views
 
 import base.SpecBase
 import forms.HistoricDateRequestPageFormProvider
-import models.{C79Certificate, CashStatement, DateMessages, DutyDefermentStatement, FileRole, HistoricDates, NormalMode, PostponedVATStatement, SecurityStatement}
+import models.{
+  C79Certificate,
+  CashStatement,
+  DateMessages,
+  DutyDefermentStatement,
+  FileRole,
+  HistoricDates,
+  NormalMode,
+  PostponedVATStatement,
+  SecurityStatement
+}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import play.api.Application

--- a/test/views/components/DownloadLinkSpec.scala
+++ b/test/views/components/DownloadLinkSpec.scala
@@ -18,7 +18,15 @@ package views.components
 
 import helpers.Formatters
 import models.FileFormat.{Csv, Pdf}
-import models._
+import models.{
+  C79Certificate,
+  CashStatement,
+  CashStatementFile,
+  CashStatementFileMetadata,
+  FileFormat,
+  VatCertificateFile,
+  VatCertificateFileMetadata
+}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.Assertion

--- a/test/views/components/DownloadLinkSpec.scala
+++ b/test/views/components/DownloadLinkSpec.scala
@@ -17,38 +17,58 @@
 package views.components
 
 import helpers.Formatters
-import models.FileFormat.Pdf
-import models.{C79Certificate, FileFormat, VatCertificateFile, VatCertificateFileMetadata}
+import models.FileFormat.{Csv, Pdf}
+import models._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.Assertion
 import views.ViewTestHelper
-import views.html.components.download_link
+import views.html.components.{download_link, download_link_cash_account}
 
 class DownloadLinkSpec extends ViewTestHelper {
 
   "Component" should {
 
-    "display the correct test" when {
+    "display the correct text for VAT certificate" when {
 
       "vat certificate file is available" in new Setup {
-        implicit val viewDoc: Document = view(Some(c79Certificates))
+        implicit val viewDoc: Document = viewVat(Some(c79Certificates))
 
-        shouldDisplayDownloadURL()
-        shouldDisplayFileFormatAndVoiceoverInfo(Pdf, size)
+        shouldDisplayDownloadURL(vatDownloadURL)
+        shouldDisplayFileFormatAndVoiceoverInfo(Pdf, vatSize)
       }
 
       "vat certificate file is not available" in new Setup {
-        implicit val viewDoc: Document = view()
+        implicit val viewDoc: Document = viewVat()
 
-        shouldDisplayMissingFileIdContents(Pdf)
+        shouldDisplayMissingFileIdContents(
+          Pdf,
+          "cf.account.vat.missing-file-hidden-text",
+          "cf.account.vat.missing-file")
+      }
+    }
+
+    "display the correct text for Cash Statement" when {
+
+      "cash statement file is available" in new Setup {
+        implicit val viewDoc: Document = viewCash(Some(cashStatementFile))
+
+        shouldDisplayDownloadURL(cashDownloadURL)
+        shouldDisplayFileFormatAndVoiceoverInfo(Csv, cashSize)
+      }
+
+      "cash statement file is not available" in new Setup {
+        implicit val viewDoc: Document = viewCash()
+
+        shouldDisplayMissingFileIdContents(Csv,
+          "cf.cash-statement-requested.missing-file-hidden-text",
+          "cf.cash-statement-requested.missing-file")
       }
     }
   }
 
-  private def shouldDisplayDownloadURL(id: String = "testId",
-                                       url: String = "download_url_00")(implicit view: Document): Assertion = {
-    view.getElementById(id).attr("href").contains(url) mustBe true
+  private def shouldDisplayDownloadURL(url: String)(implicit view: Document): Assertion = {
+    view.getElementById("testId").attr("href").contains(url) mustBe true
   }
 
   private def shouldDisplayFileFormatAndVoiceoverInfo(fileFormat: FileFormat,
@@ -58,31 +78,39 @@ class DownloadLinkSpec extends ViewTestHelper {
     val spanElements = view.getElementsByTag("span")
     spanElements.get(0).text mustBe s"${fileFormat.name} (${Formatters.fileSize(size)})"
 
-    spanElements.get(1).text mustBe msg("cf.account.vat.download-link", fileFormat,
-      period, s"${Formatters.fileSize(size)}")
+    spanElements.get(1).text mustBe msg(
+      "cf.cash-statement-requested.download-link",
+      fileFormat, period, s"${Formatters.fileSize(size)}")
   }
 
   private def shouldDisplayMissingFileIdContents(fileFormat: FileFormat,
+                                                 hiddenTextKey: String,
+                                                 missingFileKey: String,
                                                  period: String = "periodDuration")
                                                 (implicit view: Document): Assertion = {
     val spanElements = view.getElementById("missing-file-testId").getElementsByTag("span")
 
-    spanElements.get(0).text mustBe msg("cf.account.vat.missing-file-hidden-text", fileFormat, period)
-    spanElements.get(1).text mustBe msg("cf.account.vat.missing-file")
+    spanElements.get(0).text mustBe msg(hiddenTextKey, fileFormat, period)
+    spanElements.get(1).text mustBe msg(missingFileKey)
   }
 
   trait Setup {
 
-    val filename: String = "statementFile_00"
-    val downloadURL: String = "download_url_00"
-    val size: Long = 99L
+    val vatFilename: String = "vatStatementFile_00"
+    val vatDownloadURL: String = "download_url_00"
+    val vatSize: Long = 99L
     val periodStartYear: Int = 2017
     val periodStartMonth: Int = 12
+    val periodStartDay: Int = 10
+
+    val cashFilename: String = "cashStatementFile_00"
+    val cashDownloadURL: String = "download_cash_url_00"
+    val cashSize: Long = 150L
 
     val c79Certificates: VatCertificateFile = VatCertificateFile(
-      filename,
-      downloadURL,
-      size,
+      vatFilename,
+      vatDownloadURL,
+      vatSize,
       VatCertificateFileMetadata(
         periodStartYear,
         periodStartMonth,
@@ -90,10 +118,29 @@ class DownloadLinkSpec extends ViewTestHelper {
         C79Certificate,
         None))
 
+    val cashStatementFile: CashStatementFile = CashStatementFile(
+      cashFilename,
+      cashDownloadURL,
+      cashSize,
+      CashStatementFileMetadata(
+        periodStartYear,
+        periodStartMonth,
+        periodStartDay,
+        periodStartYear,
+        periodStartMonth,
+        periodStartDay,
+        Csv,
+        CashStatement,
+        Some("requestId")
+      ), "12345678")
+
     val id = "testId"
     val period = "periodDuration"
 
-    def view(vatCertificateFile: Option[VatCertificateFile] = None): Document =
+    def viewVat(vatCertificateFile: Option[VatCertificateFile] = None): Document =
       Jsoup.parse(app.injector.instanceOf[download_link].apply(vatCertificateFile, Pdf, id, period).body)
+
+    def viewCash(cashStatementFile: Option[CashStatementFile] = None): Document =
+      Jsoup.parse(app.injector.instanceOf[download_link_cash_account].apply(cashStatementFile, Csv, id, period).body)
   }
 }


### PR DESCRIPTION
Task:
- Query SDES service for cash account csv files in cash account frontend
- Create a new view for cash account statements
- Map the requested transactions link to the new page
- Add unit tests