### PR TITLE
MMCA-4996 Change FileRole value for cash account statement

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -17,7 +17,15 @@
 package config
 
 import com.google.inject.{Inject, Singleton}
-import models.{C79Certificate, CDSCashAccount, DutyDefermentStatement, FileRole, PostponedVATStatement, SecurityStatement, UserAnswers}
+import models.{
+  C79Certificate,
+  CDSCashAccount,
+  DutyDefermentStatement,
+  FileRole,
+  PostponedVATStatement,
+  SecurityStatement,
+  UserAnswers
+}
 import pages.RequestedLinkId
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -17,15 +17,7 @@
 package config
 
 import com.google.inject.{Inject, Singleton}
-import models.{
-  C79Certificate,
-  CashStatement,
-  DutyDefermentStatement,
-  FileRole,
-  PostponedVATStatement,
-  SecurityStatement,
-  UserAnswers
-}
+import models.{C79Certificate, CDSCashAccount, DutyDefermentStatement, FileRole, PostponedVATStatement, SecurityStatement, UserAnswers}
 import pages.RequestedLinkId
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -71,7 +63,7 @@ class FrontendAppConfig @Inject()(configuration: Configuration, servicesConfig: 
   lazy val sdesDutyDefermentStatementListUrl: String = sdesApi + "/files-available/list/DutyDefermentStatement"
   lazy val sdesImportVatCertificateListUrl: String = sdesApi + "/files-available/list/C79Certificate"
   lazy val sdesImportPostponedVatStatementListUrl: String = sdesApi + "/files-available/list/PostponedVATStatement"
-  lazy val sdesCashStatementListUrl: String = s"$sdesApi/files-available/list/CashStatement"
+  lazy val sdesCashStatementListUrl: String = s"$sdesApi/files-available/list/CDSCashAccount"
 
   lazy val sdesSecurityStatementListUrl: String = sdesApi + "/files-available/list/SecurityStatement"
   lazy val historicDocumentsApiUrl: String = customsFinancialsApi + "/historic-document-request"
@@ -87,7 +79,7 @@ class FrontendAppConfig @Inject()(configuration: Configuration, servicesConfig: 
 
   def deleteNotificationUrl(fileRole: FileRole, eori: String): String = {
     fileRole match {
-      case CashStatement => s"$customsFinancialsApi/eori/$eori/notifications/$fileRole"
+      case CDSCashAccount => s"$customsFinancialsApi/eori/$eori/notifications/$fileRole"
       case _ => s"$customsFinancialsApi/eori/$eori/requested-notifications/$fileRole"
     }
   }
@@ -105,7 +97,7 @@ class FrontendAppConfig @Inject()(configuration: Configuration, servicesConfig: 
       case C79Certificate => c79ReturnLink
       case SecurityStatement => adjustmentsReturnLink
       case PostponedVATStatement => postponedVatReturnLink
-      case CashStatement => cashStatementReturnLink
+      case CDSCashAccount => cashStatementReturnLink
     }
   }
 
@@ -115,7 +107,7 @@ class FrontendAppConfig @Inject()(configuration: Configuration, servicesConfig: 
       case C79Certificate => c79ReturnLink
       case SecurityStatement => adjustmentsReturnLink
       case PostponedVATStatement => postponedVatReturnLink
-      case CashStatement => cashStatementReturnLink
+      case CDSCashAccount => cashStatementReturnLink
     }
   }
 

--- a/app/controllers/HistoricStatementsController.scala
+++ b/app/controllers/HistoricStatementsController.scala
@@ -56,7 +56,7 @@ class HistoricStatementsController @Inject()(identify: IdentifierAction,
       case SecurityStatement => showHistoricSecurityStatements()
       case C79Certificate => showHistoricC79Statements()
       case PostponedVATStatement => showHistoricPostponedVatStatements()
-      case CashStatement => showHistoricCashStatements()
+      case CDSCashAccount => showHistoricCashStatements()
       case _ => Future.successful(Redirect(routes.TechnicalDifficultiesController.onPageLoad()))
     }
   }
@@ -95,7 +95,7 @@ class HistoricStatementsController @Inject()(identify: IdentifierAction,
       })
 
       viewModel = CashStatementViewModel(allCertificates.sorted)
-    } yield Ok(importCashStatementView(viewModel, appConfig.returnLink(CashStatement)))
+    } yield Ok(importCashStatementView(viewModel, appConfig.returnLink(CDSCashAccount)))
   }
 
   private def showHistoricPostponedVatStatements()(

--- a/app/models/DateMessages.scala
+++ b/app/models/DateMessages.scala
@@ -25,7 +25,7 @@ object DateMessages {
   def apply(fileRole: FileRole): DateMessages = {
 
     fileRole match {
-      case CashStatement =>
+      case CDSCashAccount =>
         DateMessages(
           startDate =
             DateMessage("cf.historic.document.request.from", "cf.historic.document.request.date.CashStatement.hint"),

--- a/app/models/FileRole.scala
+++ b/app/models/FileRole.scala
@@ -25,7 +25,7 @@ case object DutyDefermentStatement extends FileRole("DutyDefermentStatement")
 case object C79Certificate extends FileRole("C79Certificate")
 case object SecurityStatement extends FileRole("SecurityStatement")
 case object PostponedVATStatement extends FileRole("PostponedVATStatement")
-case object CashStatement extends FileRole("CashStatement")
+case object CDSCashAccount extends FileRole("CDSCashAccount")
 
 object FileRole {
   implicit val format: Format[FileRole] = new Format[FileRole] {
@@ -35,7 +35,7 @@ object FileRole {
         case JsString("C79Certificate") => JsSuccess(C79Certificate)
         case JsString("SecurityStatement") => JsSuccess(SecurityStatement)
         case JsString("PostponedVATStatement") => JsSuccess(PostponedVATStatement)
-        case JsString("CashStatement") => JsSuccess(CashStatement)
+        case JsString("CDSCashAccount") => JsSuccess(CDSCashAccount)
         case e => JsError(s"Invalid file role: $e")
       }
     }
@@ -49,7 +49,7 @@ object FileRole {
         case "duty-deferment" => Right(DutyDefermentStatement)
         case "adjustments" => Right(SecurityStatement)
         case "postponed-vat" => Right(PostponedVATStatement)
-        case "cash-statement" => Right(CashStatement)
+        case "cash-statement" => Right(CDSCashAccount)
         case fileRole => Left(s"unknown file role: $fileRole")
       }
     }
@@ -60,7 +60,7 @@ object FileRole {
         case DutyDefermentStatement => "duty-deferment"
         case SecurityStatement => "adjustments"
         case PostponedVATStatement => "postponed-vat"
-        case CashStatement => "cash-statement"
+        case CDSCashAccount => "cash-statement"
       }
     }
   }

--- a/app/services/SdesGatekeeperService.scala
+++ b/app/services/SdesGatekeeperService.scala
@@ -135,7 +135,7 @@ class SdesGatekeeperService() {
       case "SecurityStatement" => SecurityStatement
       case "DutyDefermentStatement" => DutyDefermentStatement
       case "PostponedVATStatement" => PostponedVATStatement
-      case "CashStatement" => CashStatement
+      case "CDSCashAccount" => CDSCashAccount
       case _ => throw new Exception(s"Unknown file role: $role")
     }
   }

--- a/app/services/SortStatementsService.scala
+++ b/app/services/SortStatementsService.scala
@@ -53,7 +53,7 @@ class SortStatementsService @Inject()() {
     }.toList
 
     val filteredByStatementRequestId = groupedByMonth.map { statementByMonth =>
-      val filteredFiles = statementByMonth.files.filter(_.metadata.statementRequestId.isDefined)
+      val filteredFiles = statementByMonth.files.filter(_.metadata.statementRequestId.isEmpty)
 
       CashStatementByMonth(statementByMonth.date, filteredFiles)
     }

--- a/test/config/FrontendAppConfigSpec.scala
+++ b/test/config/FrontendAppConfigSpec.scala
@@ -17,7 +17,7 @@
 package config
 
 import base.SpecBase
-import models.{C79Certificate, CashStatement, DutyDefermentStatement, PostponedVATStatement, SecurityStatement}
+import models.{C79Certificate, CDSCashAccount, DutyDefermentStatement, PostponedVATStatement, SecurityStatement}
 import org.scalatest.TryValues.convertTryToSuccessOrFailure
 import pages.RequestedLinkId
 import play.api.Application
@@ -43,7 +43,7 @@ class FrontendAppConfigSpec extends SpecBase {
     }
 
     "return the adjustments link if a CashStatement FileRole provided" in new Setup {
-      config.returnLink(CashStatement, emptyUserAnswers) mustBe
+      config.returnLink(CDSCashAccount, emptyUserAnswers) mustBe
         "http://localhost:9394/customs/cash-account"
     }
 
@@ -76,8 +76,8 @@ class FrontendAppConfigSpec extends SpecBase {
 
   "deleteNotificationUrl" should {
     "return correct url for cash account FileRole" in new Setup {
-      config.deleteNotificationUrl(CashStatement, "GB123456789000") mustBe
-        "http://localhost:9878/customs-financials-api/eori/GB123456789000/notifications/CashStatement"
+      config.deleteNotificationUrl(CDSCashAccount, "GB123456789000") mustBe
+        "http://localhost:9878/customs-financials-api/eori/GB123456789000/notifications/CDSCashAccount"
     }
 
     "return correct url for C79 certificate FileRole" in new Setup {

--- a/test/config/FrontendAppConfigSpec.scala
+++ b/test/config/FrontendAppConfigSpec.scala
@@ -31,6 +31,13 @@ class FrontendAppConfigSpec extends SpecBase {
     }
   }
 
+  "sdesCashStatementListUrl" should {
+    "return correct sdes url" in new Setup {
+      config.sdesCashStatementListUrl mustBe
+        "http://localhost:9754/customs-financials-sdes-stub/files-available/list/CDSCashAccount"
+    }
+  }
+
   "returnLink" should {
     "return the adjustments link if a SecurityStatement FileRole provided" in new Setup {
       config.returnLink(SecurityStatement, emptyUserAnswers) mustBe
@@ -42,7 +49,7 @@ class FrontendAppConfigSpec extends SpecBase {
         "http://localhost:9398/customs/documents/import-vat"
     }
 
-    "return the adjustments link if a CashStatement FileRole provided" in new Setup {
+    "return the cash account link if a CDSCashAccount FileRole and User Answers provided" in new Setup {
       config.returnLink(CDSCashAccount, emptyUserAnswers) mustBe
         "http://localhost:9394/customs/cash-account"
     }
@@ -52,6 +59,11 @@ class FrontendAppConfigSpec extends SpecBase {
         DutyDefermentStatement,
         emptyUserAnswers.set(RequestedLinkId, "someLink").success.value) mustBe
         "http://localhost:9397/customs/duty-deferment/someLink/account"
+    }
+
+    "return the cash account link if a CDSCashAccount FileRole provided" in new Setup {
+      config.returnLink(CDSCashAccount) mustBe
+        "http://localhost:9394/customs/cash-account"
     }
 
     "throw an exception if DutyDeferment FileRole and no linkId in user answers" in new Setup {

--- a/test/connectors/SdesConnectorSpec.scala
+++ b/test/connectors/SdesConnectorSpec.scala
@@ -169,13 +169,13 @@ class SdesConnectorSpec extends SpecBase {
         MetadataItem("PeriodStartYear", "2018"), MetadataItem("PeriodStartMonth", "3"),
         MetadataItem("PeriodStartDay", "14"), MetadataItem("PeriodEndYear", "2018"),
         MetadataItem("PeriodEndMonth", "3"), MetadataItem("PeriodEndDay", "31"),
-        MetadataItem("FileType", "PDF"), MetadataItem("FileRole", "CashStatement")))),
+        MetadataItem("FileType", "PDF"), MetadataItem("FileRole", "CDSCashAccount")))),
 
       FileInformation("cash_statement_02", "download_url_02", size, Metadata(List(
         MetadataItem("PeriodStartYear", "2018"), MetadataItem("PeriodStartMonth", "2"),
         MetadataItem("PeriodStartDay", "14"), MetadataItem("PeriodEndYear", "2018"),
         MetadataItem("PeriodEndMonth", "2"), MetadataItem("PeriodEndDay", "28"),
-        MetadataItem("FileType", "PDF"), MetadataItem("FileRole", "CashStatement")))))
+        MetadataItem("FileType", "PDF"), MetadataItem("FileRole", "CDSCashAccount")))))
 
     val cashStatementFiles: Seq[CashStatementFile] = List(
       CashStatementFile("cash_statement_01", "download_url_01", size, CashStatementFileMetadata(

--- a/test/connectors/SdesConnectorSpec.scala
+++ b/test/connectors/SdesConnectorSpec.scala
@@ -33,6 +33,7 @@ import org.mockito.Mockito.when
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.{eq => eqTo}
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -161,7 +162,7 @@ class SdesConnectorSpec extends SpecBase {
     val size = 111L
 
     val sdesCashStatementsUrl =
-      "http://localhost:9754/customs-financials-sdes-stub/files-available/list/CashStatement"
+      "http://localhost:9754/customs-financials-sdes-stub/files-available/list/CDSCashAccount"
 
     val cashStatementFilesSdesResponse: Seq[FileInformation] = List(
       FileInformation("cash_statement_01", "download_url_01", size, Metadata(List(
@@ -178,10 +179,10 @@ class SdesConnectorSpec extends SpecBase {
 
     val cashStatementFiles: Seq[CashStatementFile] = List(
       CashStatementFile("cash_statement_01", "download_url_01", size, CashStatementFileMetadata(
-        year, month, day, year, month, day + 17, Pdf, CashStatement, None)),
+        year, month, day, year, month, day + 17, Pdf, CDSCashAccount, None)),
 
       CashStatementFile("cash_statement_02", "download_url_02", size, CashStatementFileMetadata(
-        year, month - 1, day, year, month - 1, day + 14, Pdf, CashStatement, None)))
+        year, month - 1, day, year, month - 1, day + 14, Pdf, CDSCashAccount, None)))
 
     val cashStatementFilesWithUnknownFileRoleSdesResponse: Seq[FileInformation] = List(
       FileInformation("cash_statement_01", "download_url_01", size, Metadata(List(

--- a/test/controllers/HistoricStatementsControllerSpec.scala
+++ b/test/controllers/HistoricStatementsControllerSpec.scala
@@ -66,7 +66,7 @@ class HistoricStatementsControllerSpec extends SpecBase {
         .thenReturn(Future.successful(cashStatementFiles))
 
       val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest(GET,
-        controllers.routes.HistoricStatementsController.historicStatements(CashStatement).url)
+        controllers.routes.HistoricStatementsController.historicStatements(CDSCashAccount).url)
 
       running(app) {
         val result = route(app, request).value
@@ -191,7 +191,7 @@ class HistoricStatementsControllerSpec extends SpecBase {
       "statementfile_01",
       "download_url_01",
       size,
-      CashStatementFileMetadata(year, one, one, year, one, one, Pdf, CashStatement, None))
+      CashStatementFileMetadata(year, one, one, year, one, one, Pdf, CDSCashAccount, None))
 
     val cashStatementFiles: Seq[CashStatementFile] = Seq(
       cashStatementFile,
@@ -199,7 +199,7 @@ class HistoricStatementsControllerSpec extends SpecBase {
         "statementfile_02",
         "download_url_02",
         size,
-        CashStatementFileMetadata(year, one, one, year, one, one, Pdf, CashStatement, None)))
+        CashStatementFileMetadata(year, one, one, year, one, one, Pdf, CDSCashAccount, None)))
 
     val dutyDeferementFile: DutyDefermentStatementFile = DutyDefermentStatementFile(
       "2018_03_01-08.pdf", "url.pdf", size,

--- a/test/models/DateMessagesSpec.scala
+++ b/test/models/DateMessagesSpec.scala
@@ -48,8 +48,8 @@ class DateMessagesSpec extends SpecBase {
           hintMsgKey = "cf.historic.document.request.endDate.hint")
       }
 
-      "fileRole is CashStatement" in {
-        val actual = DateMessages(CashStatement)
+      "fileRole is CDSCashAccount" in {
+        val actual = DateMessages(CDSCashAccount)
 
         actual.startDate mustBe DateMessage(
           labelMsgKey = "cf.historic.document.request.from",

--- a/test/models/FileRoleSpec.scala
+++ b/test/models/FileRoleSpec.scala
@@ -39,7 +39,7 @@ class FileRoleSpec extends SpecBase {
     }
 
     "return a JsSuccess for CashStatement" in {
-      JsString("CashStatement").as[FileRole] mustBe CashStatement
+      JsString("CDSCashAccount").as[FileRole] mustBe CDSCashAccount
     }
 
     "return exception for unknown file role" in {

--- a/test/models/FileRoleSpec.scala
+++ b/test/models/FileRoleSpec.scala
@@ -18,6 +18,7 @@ package models
 
 import base.SpecBase
 import play.api.libs.json.{JsResultException, JsString}
+import play.api.mvc.PathBindable
 
 class FileRoleSpec extends SpecBase {
 
@@ -38,7 +39,7 @@ class FileRoleSpec extends SpecBase {
       JsString("PostponedVATStatement").as[FileRole] mustBe PostponedVATStatement
     }
 
-    "return a JsSuccess for CashStatement" in {
+    "return a JsSuccess for CDSCashAccount" in {
       JsString("CDSCashAccount").as[FileRole] mustBe CDSCashAccount
     }
 
@@ -46,6 +47,23 @@ class FileRoleSpec extends SpecBase {
       intercept[JsResultException] {
         JsString("Unknown").as[FileRole]
       }
+    }
+  }
+
+  "FileRole.pathBinder" should {
+    val pathBindable: PathBindable[FileRole] = implicitly[PathBindable[FileRole]]
+
+    "bind 'cash-statement' to Right(CDSCashAccount)" in {
+      pathBindable.bind("fileRole", "cash-statement") mustBe Right(CDSCashAccount)
+    }
+
+    "unbind CDSCashAccount to 'cash-statement'" in {
+      pathBindable.unbind("fileRole", CDSCashAccount) mustBe "cash-statement"
+    }
+
+    "return Left with error for unknown file role in bind" in {
+      val unknownRole = "unknown-role"
+      pathBindable.bind("fileRole", unknownRole) mustBe Left(s"unknown file role: $unknownRole")
     }
   }
 }

--- a/test/models/SdesFileSpec.scala
+++ b/test/models/SdesFileSpec.scala
@@ -115,7 +115,7 @@ class SdesFileSpec extends SpecBase with Matchers {
         periodEndMonth = month,
         periodEndDay = day,
         fileFormat = Csv,
-        fileRole = CashStatement,
+        fileRole = CDSCashAccount,
         cashAccountNumber = None,
         statementRequestId = None
       ), "123456789")
@@ -132,7 +132,7 @@ class SdesFileSpec extends SpecBase with Matchers {
         periodEndMonth = month,
         periodEndDay = day,
         fileFormat = Csv,
-        fileRole = CashStatement,
+        fileRole = CDSCashAccount,
         cashAccountNumber = None,
         statementRequestId = None
       ), "123456789")

--- a/test/services/SdesGatekeeperServiceSpec.scala
+++ b/test/services/SdesGatekeeperServiceSpec.scala
@@ -40,7 +40,7 @@ class SdesGatekeeperServiceSpec extends SpecBase {
       result.metadata.periodEndMonth mustBe periodEndMonth
       result.metadata.periodEndDay mustBe periodEndDay
       result.metadata.fileFormat mustBe FileFormat(csv)
-      result.metadata.fileRole mustBe CashStatement
+      result.metadata.fileRole mustBe CDSCashAccount
       result.metadata.cashAccountNumber mustBe someAccountNumber
       result.metadata.statementRequestId mustBe someRequestId
     }
@@ -134,7 +134,7 @@ class SdesGatekeeperServiceSpec extends SpecBase {
         periodEndDay = periodEndDay,
         fileFormat = FileFormat(csv),
         statementRequestId = someRequestId,
-        fileRole = CashStatement,
+        fileRole = CDSCashAccount,
         cashAccountNumber = someAccountNumber
       ), eori = emptyString)
 
@@ -150,7 +150,7 @@ class SdesGatekeeperServiceSpec extends SpecBase {
         MetadataItem("PeriodEndMonth", periodEndMonth.toString),
         MetadataItem("PeriodEndDay", periodEndDay.toString),
         MetadataItem("FileType", csv),
-        MetadataItem("FileRole", "CashStatement"),
+        MetadataItem("FileRole", "CDSCashAccount"),
         MetadataItem("CashAccountNumber", someAccountNumber.getOrElse(emptyString)),
         MetadataItem("statementRequestID", someRequestId.getOrElse(emptyString)))))
 

--- a/test/services/SortStatementsServiceSpec.scala
+++ b/test/services/SortStatementsServiceSpec.scala
@@ -95,9 +95,9 @@ class SortStatementsServiceSpec extends SpecBase {
         periodEndMonth,
         periodEndDay,
         Pdf,
-        CashStatement,
+        CDSCashAccount,
         someAccountNumber,
-        someRequestId
+        None
       ), someEori)
 
     val cashStatementFileCsv: CashStatementFile = CashStatementFile(
@@ -112,9 +112,9 @@ class SortStatementsServiceSpec extends SpecBase {
         periodEndMonth,
         periodEndDay,
         Csv,
-        CashStatement,
+        CDSCashAccount,
         someAccountNumber,
-        someRequestId
+        None
       ), someEori)
 
     val cashStatementFilePdf_2: CashStatementFile = CashStatementFile(
@@ -129,15 +129,12 @@ class SortStatementsServiceSpec extends SpecBase {
         periodEndMonth,
         periodEndDay,
         Pdf,
-        CashStatement,
+        CDSCashAccount,
         someAccountNumber,
         someRequestId
       ), someEori)
 
     val requestedCashStatements: Seq[CashStatementByMonth] = List(
-      CashStatementByMonth(
-        LocalDate.of(periodStartYear - 1, periodStartMonth, periodStartDay),
-        Seq(cashStatementFilePdf_2)),
       CashStatementByMonth(
         LocalDate.of(periodStartYear, periodStartMonth, periodStartDay),
         Seq(cashStatementFilePdf, cashStatementFileCsv)))

--- a/test/viewmodels/CashStatementViewModelSpec.scala
+++ b/test/viewmodels/CashStatementViewModelSpec.scala
@@ -209,7 +209,7 @@ class CashStatementViewModelSpec extends SpecBase {
       periodEndMonth = periodEndMonth - 1,
       periodEndDay = periodEndDay,
       fileFormat = Csv,
-      fileRole = CashStatement,
+      fileRole = CDSCashAccount,
       cashAccountNumber = accountNumber,
       statementRequestId = None)
 
@@ -221,7 +221,7 @@ class CashStatementViewModelSpec extends SpecBase {
       periodEndMonth = periodEndMonth,
       periodEndDay = periodEndDay,
       fileFormat = Pdf,
-      fileRole = CashStatement,
+      fileRole = CDSCashAccount,
       cashAccountNumber = accountNumber,
       statementRequestId = None)
 

--- a/test/views/CashStatementViewSpec.scala
+++ b/test/views/CashStatementViewSpec.scala
@@ -17,7 +17,7 @@
 package views
 
 import models.FileFormat.Csv
-import models.{CashStatement, CashStatementFile, CashStatementFileMetadata, EoriHistory}
+import models.{CDSCashAccount, CashStatementFile, CashStatementFileMetadata, EoriHistory}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.Assertion
@@ -32,7 +32,7 @@ class CashStatementViewSpec extends ViewTestHelper {
 
     "display correct title and contents" in new Setup {
       titleShouldBeCorrect(view, "cf.cash-statement-requested-heading")
-      pageShouldContainBackLinkUrl(view, config.returnLink(CashStatement))
+      pageShouldContainBackLinkUrl(view, config.returnLink(CDSCashAccount))
       headingShouldBeCorrect
       requestedParagraphTextShouldBeCorrect
       requestedListParagraphTextShouldBeCorrect
@@ -93,7 +93,7 @@ class CashStatementViewSpec extends ViewTestHelper {
         periodStartMonth,
         periodStartDay,
         Csv,
-        CashStatement,
+        CDSCashAccount,
         Some("requestId")
       ), someEori)
 
@@ -112,6 +112,6 @@ class CashStatementViewSpec extends ViewTestHelper {
 
     implicit val view: Document = Jsoup.parse(app.injector.instanceOf[CashStatementView].apply(
       cashStatementViewModel,
-      config.returnLink(CashStatement)).body)
+      config.returnLink(CDSCashAccount)).body)
   }
 }

--- a/test/views/HistoricDateRequestPageViewSpec.scala
+++ b/test/views/HistoricDateRequestPageViewSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import forms.HistoricDateRequestPageFormProvider
 import models.{
   C79Certificate,
-  CashStatement,
+  CDSCashAccount,
   DateMessages,
   DutyDefermentStatement,
   FileRole,
@@ -129,7 +129,7 @@ trait SetUpWithSpecBase extends SpecBase {
       case PostponedVATStatement => msgs("cf.historic.document.request.date.PostponedVATStatement.hint")
       case DutyDefermentStatement => msgs("cf.historic.document.request.date.DutyDefermentStatement.hint")
       case SecurityStatement => msgs("cf.historic.document.request.date.SecurityStatement.hint")
-      case CashStatement => msgs("cf.historic.document.request.date.CashStatement.hint")
+      case CDSCashAccount => msgs("cf.historic.document.request.date.CashStatement.hint")
     }
   }
 

--- a/test/views/components/DownloadLinkSpec.scala
+++ b/test/views/components/DownloadLinkSpec.scala
@@ -20,7 +20,7 @@ import helpers.Formatters
 import models.FileFormat.{Csv, Pdf}
 import models.{
   C79Certificate,
-  CashStatement,
+  CDSCashAccount,
   CashStatementFile,
   CashStatementFileMetadata,
   FileFormat,
@@ -138,7 +138,7 @@ class DownloadLinkSpec extends ViewTestHelper {
         periodStartMonth,
         periodStartDay,
         Csv,
-        CashStatement,
+        CDSCashAccount,
         Some("requestId")
       ), "12345678")
 


### PR DESCRIPTION
Due to ETMP using a different filerole value in cash statement metadata, FileRole value for cash statement is changed from 'CashStatement' to 'CDSCashAccount'