### PR TITLE
[MMCA-5111] Fix the accessibility test finding

### DIFF
--- a/app/views/ConfirmationPageView.scala.html
+++ b/app/views/ConfirmationPageView.scala.html
@@ -22,7 +22,8 @@
     layout: Layout,
     link: components.link,
     p: components.p,
-    h1: components.h1
+    h1: components.h1,
+    h2: components.h2
 )
 
 @(
@@ -52,10 +53,10 @@
         )
     </div>
 
-    @p(
+    @h2(
         classes="govuk-heading-s",
         id=Some("email-confirmation-subheader"),
-        content = Html(messages(s"cf.historic.document.request.confirmation.subheader-text.next"))
+        msg = messages(s"cf.historic.document.request.confirmation.subheader-text.next")
     )
 
     @email.map { addr =>

--- a/app/views/ConfirmationPageView.scala.html
+++ b/app/views/ConfirmationPageView.scala.html
@@ -38,7 +38,7 @@
 )
 
 @layout(
-    pageTitle = Some(messages("cf.accounts.title")),
+    pageTitle = Some(messages(s"cf.historic.document.request.confirmation.panel-text.${fileRole.name}")),
     dutyDeferment = fileRole == DutyDefermentStatement
     ) {
 

--- a/test/viewmodels/DutyDefermentAccountViewModelSpec.scala
+++ b/test/viewmodels/DutyDefermentAccountViewModelSpec.scala
@@ -107,8 +107,8 @@ class DutyDefermentAccountViewModelSpec extends SpecBase {
     private val periodEndDay              = 8
     private val dutyPaymentType           = "BACS"
 
-    val currentYear                       = currentDate.getYear.toString
-    val currentMonth                      = currentDate.getMonthValue.toString
+    val currentYear  = currentDate.getYear.toString
+    val currentMonth = currentDate.getMonthValue.toString
 
     val app: Application        = applicationBuilder().build()
     implicit val msgs: Messages = messages(app)

--- a/test/viewmodels/DutyDefermentAccountViewModelSpec.scala
+++ b/test/viewmodels/DutyDefermentAccountViewModelSpec.scala
@@ -68,11 +68,11 @@ class DutyDefermentAccountViewModelSpec extends SpecBase {
 
       statementsString must include("<dl  class=govuk-summary-list>")
       statementsString must include(
-        "<div id=requested-statements-list-0-2024-12-row-0 class=govuk-summary-list__row>"
+        s"""<div id=requested-statements-list-0-$currentYear-$currentMonth-row-0 class=govuk-summary-list__row>"""
       )
 
       statementsString must include(
-        "<dt id=requested-statements-list-0-2024-12-row-0-date-cell class=govuk-summary-list__value>Duty deferment 1720</dt>"
+        s"""<dt id=requested-statements-list-0-$currentYear-$currentMonth-row-0-date-cell class=govuk-summary-list__value>Duty deferment 1720</dt>"""
       )
     }
 
@@ -106,6 +106,9 @@ class DutyDefermentAccountViewModelSpec extends SpecBase {
     private val periodEndMonth            = 2
     private val periodEndDay              = 8
     private val dutyPaymentType           = "BACS"
+
+    val currentYear                       = currentDate.getYear.toString
+    val currentMonth                      = currentDate.getMonthValue.toString
 
     val app: Application        = applicationBuilder().build()
     implicit val msgs: Messages = messages(app)

--- a/test/views/ConfirmationPageViewSpec.scala
+++ b/test/views/ConfirmationPageViewSpec.scala
@@ -37,7 +37,8 @@ class ConfirmationPageViewSpec extends SpecBase {
     "display correct text" when {
 
       "title should display correctly" in new Setup {
-        view.title() mustBe s"${messages(app)("cf.accounts.title")} - ${messages(app)("service.name")} - GOV.UK"
+        view
+          .title() mustBe s"${messages(app)(s"cf.historic.document.request.confirmation.panel-text.${fileRole.name}")} - ${messages(app)("service.name")} - GOV.UK"
       }
 
       "date should display correctly" in new Setup {

--- a/test/views/ConfirmationPageViewSpec.scala
+++ b/test/views/ConfirmationPageViewSpec.scala
@@ -38,7 +38,7 @@ class ConfirmationPageViewSpec extends SpecBase {
 
       "title should display correctly" in new Setup {
         view
-          .title() mustBe 
+          .title() mustBe
           s"${messages(app)(s"cf.historic.document.request.confirmation.panel-text.${fileRole.name}")} - " +
           s"${messages(app)("service.name")} - GOV.UK"
       }

--- a/test/views/ConfirmationPageViewSpec.scala
+++ b/test/views/ConfirmationPageViewSpec.scala
@@ -44,10 +44,11 @@ class ConfirmationPageViewSpec extends SpecBase {
         view.getElementById("email-confirmation-panel-date").text() mustBe messages(app)("03 Oct 2021 to 04 Sept 2022")
       }
 
-      "subheader-text should display correctly" in new Setup {
-        view.getElementById("email-confirmation-subheader").text() mustBe messages(app)(
+      "subheader-text should be an H2 and display correctly" in new Setup {
+        subheaderElement.text() mustBe messages(app)(
           "cf.historic.document.request.confirmation.subheader-text.next"
         )
+        subheaderElement.tagName() mustBe "h2"
       }
 
       "email confirmation should display correctly" in new Setup {
@@ -102,5 +103,7 @@ class ConfirmationPageViewSpec extends SpecBase {
 
     val view: Document =
       Jsoup.parse(app.injector.instanceOf[ConfirmationPageView].apply(Some(email), fileRole, returnLink, dates).body)
+
+    val subheaderElement = view.getElementsByTag("h2").first()
   }
 }

--- a/test/views/ConfirmationPageViewSpec.scala
+++ b/test/views/ConfirmationPageViewSpec.scala
@@ -38,7 +38,9 @@ class ConfirmationPageViewSpec extends SpecBase {
 
       "title should display correctly" in new Setup {
         view
-          .title() mustBe s"${messages(app)(s"cf.historic.document.request.confirmation.panel-text.${fileRole.name}")} - ${messages(app)("service.name")} - GOV.UK"
+          .title() mustBe 
+          s"${messages(app)(s"cf.historic.document.request.confirmation.panel-text.${fileRole.name}")} - " +
+          s"${messages(app)("service.name")} - GOV.UK"
       }
 
       "date should display correctly" in new Setup {


### PR DESCRIPTION
[Tasks]
- Changed the `<p>` tag to an `<h2>` tag to fix an accessibility issue
- Ensured better compliance with WCAG accessibility guidelines
- Updated page title to match `H1` text as per GOV.UK Design System
- Updated unit tests to validate the change
- Updated `DutyDefermentAccountViewModelSpec` tests to dynamically use the current year and month, ensuring they remain future-proof by adapting to real-time date changes
