### PR TITLE
[MMCA-5240] Updated confirmation return link to financialsHomepage and remove unused route

### DIFF
--- a/app/controllers/ConfirmationPageController.scala
+++ b/app/controllers/ConfirmationPageController.scala
@@ -52,7 +52,7 @@ class ConfirmationPageController @Inject() (
     implicit request =>
 
       val dates      = new CheckYourAnswersHelper(request.userAnswers)
-      val returnLink = routes.ConfirmationPageController.returnToStatementsPage(fileRole).url
+      val returnLink = appConfig.financialsHomepage
 
       for {
         _     <- sessionRepository.set(userAnswersWithNoHistoricDates(fileRole, request))
@@ -61,13 +61,6 @@ class ConfirmationPageController @Inject() (
         view(email, fileRole, returnLink, dates.dateRows(fileRole).getOrElse(emptyString))
       )
   }
-
-  def returnToStatementsPage(fileRole: FileRole): Action[AnyContent] =
-    (identify andThen getData andThen requireData).async { implicit request =>
-      for {
-        _ <- sessionRepository.clear(request.internalId).recover { case _ => true }
-      } yield Redirect(appConfig.returnLink(fileRole, request.userAnswers))
-    }
 
   private def userAnswersWithNoHistoricDates(fileRole: FileRole, request: DataRequest[AnyContent]): UserAnswers =
     request.userAnswers.remove(HistoricDateRequestPage(fileRole)) match {

--- a/app/views/ConfirmationPageView.scala.html
+++ b/app/views/ConfirmationPageView.scala.html
@@ -73,7 +73,7 @@
     )
 
     @link(linkMessage = messages(
-        s"cf.historic.document.request.confirmation.${fileRole.name}.link-text"),
+        "cf.historic.document.request.confirmation.back-to-dashboard.link-text"),
         location = returnLink,
         pId = Some("link-text"),
         pClass = "govuk-body govuk-!-margin-bottom-9")

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -25,7 +25,6 @@ GET         /:fileRole/selected-statements               controllers.CheckYourAn
 POST        /:fileRole/selected-statements               controllers.CheckYourAnswersController.onSubmit(fileRole: FileRole)
 
 GET         /:fileRole/confirmation                      controllers.ConfirmationPageController.onPageLoad(fileRole: FileRole)
-GET         /:fileRole/confirmation/return-to-statements controllers.ConfirmationPageController.returnToStatementsPage(fileRole: FileRole)
 
 GET         /requested/:fileRole                         controllers.HistoricStatementsController.historicStatements(fileRole: FileRole)
 GET         /requested/duty-deferment/:linkId            controllers.HistoricStatementsController.historicStatementsDutyDeferment(linkId: String)

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -123,6 +123,7 @@ cf.historic.document.request.confirmation.DutyDefermentStatement.link-text=Yn ô
 cf.historic.document.request.confirmation.SecurityStatement.link-text=Yn ôl i ‘Hysbysiad o ddatganiadau addasu’
 cf.historic.document.request.confirmation.PostponedVATStatement.link-text=Yn ôl i ddatganiadau TAW mewnforio ohiriedig
 cf.historic.document.request.confirmation.body-text.SecurityStatement=Byddwn yn anfon e-bost at {0} pan fydd eich datganiadau yn barod. Gallwch ddod o hyd iddyn nhw o’r dudalen datganiadau, fel arfer cyn pen 48 awr.
+cf.historic.document.request.confirmation.back-to-dashboard.link-text=Yn ôl i hafan ‘Rheoli tollau mewnforio a chyfrifon TAW’
 
 cf.historic.document.request.confirmation.subheader-text.next=Yr hyn sy’n digwydd nesaf
 cf.historic.document.request.confirmation.body-text.request=Byddwn yn anfon e-bost at {0} cyn pen 48 awr pan fydd eich cais wedi’i brosesu.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -123,6 +123,7 @@ cf.historic.document.request.confirmation.DutyDefermentStatement.link-text=Back 
 cf.historic.document.request.confirmation.SecurityStatement.link-text=Back to notification of adjustment statements
 cf.historic.document.request.confirmation.PostponedVATStatement.link-text=Back to postponed import VAT statements
 cf.historic.document.request.confirmation.body-text.SecurityStatement=We will send an email to {0} when your statements are ready. You can access them from the statements page, usually within 48 hours.
+cf.historic.document.request.confirmation.back-to-dashboard.link-text=Back to Manage import duties and VAT accounts homepage
 
 cf.historic.document.request.confirmation.subheader-text.next=What happens next
 cf.historic.document.request.confirmation.body-text.request=We''ll send an email within 48 hours to {0} when your request is processed.

--- a/test/controllers/ConfirmationPageControllerSpec.scala
+++ b/test/controllers/ConfirmationPageControllerSpec.scala
@@ -34,7 +34,7 @@ class ConfirmationPageControllerSpec extends SpecBase {
 
   "onPageLoad" must {
 
-    "return OK and the correct view for a GET" in new Setup {
+    "return OK and the correct view including a return link to the MIDVA dashboard" in new Setup {
 
       when(mockDataStoreConnector.getEmail(any)).thenReturn(Future.successful(Right(Email("some@email.com"))))
       when(mockSessionRepository.set(any)).thenReturn(Future.successful(true))
@@ -52,6 +52,8 @@ class ConfirmationPageControllerSpec extends SpecBase {
             appConfig.financialsHomepage,
             "March 2018 to March 2018"
           )(request, messages, appConfig).toString
+
+        contentAsString(result) must include(appConfig.financialsHomepage)
       }
     }
   }

--- a/test/controllers/ConfirmationPageControllerSpec.scala
+++ b/test/controllers/ConfirmationPageControllerSpec.scala
@@ -49,38 +49,9 @@ class ConfirmationPageControllerSpec extends SpecBase {
           view(
             Some(Email("some@email.com")),
             C79Certificate,
-            routes.ConfirmationPageController.returnToStatementsPage(C79Certificate).url,
+            appConfig.financialsHomepage,
             "March 2018 to March 2018"
           )(request, messages, appConfig).toString
-      }
-    }
-  }
-
-  "returnToStatementsPage" must {
-
-    "redirect to statements page" when {
-
-      "user session is cleared successfully" in new Setup {
-
-        when(mockSessionRepository.clear(any)).thenReturn(Future.successful(true))
-
-        running(app) {
-          val request = fakeRequest(GET, routes.ConfirmationPageController.returnToStatementsPage(C79Certificate).url)
-          val result  = route(app, request).value
-
-          status(result) mustBe SEE_OTHER
-        }
-      }
-
-      "error occurs in clearing user session" in new Setup {
-        when(mockSessionRepository.clear(any)).thenReturn(Future.failed(new RuntimeException("error occurred")))
-
-        running(app) {
-          val request = fakeRequest(GET, routes.ConfirmationPageController.returnToStatementsPage(C79Certificate).url)
-          val result  = route(app, request).value
-
-          status(result) mustBe SEE_OTHER
-        }
       }
     }
   }

--- a/test/views/ConfirmationPageViewSpec.scala
+++ b/test/views/ConfirmationPageViewSpec.scala
@@ -72,7 +72,7 @@ class ConfirmationPageViewSpec extends SpecBase {
 
       "link should display correct text" in new Setup {
         view.getElementById("link-text").text() mustBe messages(
-          s"cf.historic.document.request.confirmation.${fileRole.name}.link-text"
+          "cf.historic.document.request.confirmation.back-to-dashboard.link-text"
         )
       }
     }


### PR DESCRIPTION
[Tasks]

- Updated `ConfirmationPageController` to use `appConfig.financialsHomepage` as the return link
- Removed `returnToStatementsPage` method and corresponding route from app.routes
- Adjusted test to verify financialsHomepage is rendered

[Note]
- Bobby warnings are addressed in this [PR](https://github.com/hmrc/customs-historic-statement-frontend/pull/163)