### PR TITLE
MMCA-5338: Create link to feedback form from confirmation page

### DIFF
--- a/app/views/ConfirmationPageView.scala.html
+++ b/app/views/ConfirmationPageView.scala.html
@@ -21,6 +21,7 @@
 @this(
     layout: Layout,
     link: components.link,
+    newTabLink: components.newTabLink,
     p: components.p,
     h1: components.h1,
     h2: components.h2
@@ -76,5 +77,24 @@
         "cf.historic.document.request.confirmation.back-to-dashboard.link-text"),
         location = returnLink,
         pId = Some("link-text"),
-        pClass = "govuk-body govuk-!-margin-bottom-9")
+    )
+        
+    @h2(
+        classes="govuk-heading-s",
+        id=Some("email-confirmation-subheader-help"),
+        msg = messages(s"cf.historic.document.request.confirmation.subheader-text.help")
+    )
+
+    @p(
+        classes="govuk-body",
+        id=Some("email-confirmation-body-help"),
+        content = Html(messages(s"cf.historic.document.request.confirmation.body-text.help"))
+    )
+
+    @newTabLink(
+        linkMessage = messages(
+        "cf.historic.document.request.confirmation.link.help"),
+        href = appConfig.helpMakeGovUkBetterUrl,
+        classes = "govuk-body govuk-!-margin-bottom-9 hmrc-user-research-banner-link"
+    )
 }

--- a/app/views/ConfirmationPageView.scala.html
+++ b/app/views/ConfirmationPageView.scala.html
@@ -81,20 +81,19 @@
         
     @h2(
         classes="govuk-heading-s",
-        id=Some("email-confirmation-subheader-help"),
-        msg = messages(s"cf.historic.document.request.confirmation.subheader-text.help")
+        id=Some("improve-the-service-heading"),
+        msg = messages("cf.historic.document.request.confirmation.subheader-text.help")
     )
 
     @p(
         classes="govuk-body",
-        id=Some("email-confirmation-body-help"),
+        id=Some("improve-the-service-body"),
         content = Html(messages(s"cf.historic.document.request.confirmation.body-text.help"))
     )
 
     @newTabLink(
-        linkMessage = messages(
-        "cf.historic.document.request.confirmation.link.help"),
+        linkMessage = messages("cf.historic.document.request.confirmation.link.help"),
         href = appConfig.helpMakeGovUkBetterUrl,
-        classes = "govuk-body govuk-!-margin-bottom-9 hmrc-user-research-banner-link"
+        classes = "govuk-body govuk-!-margin-bottom-9 improve-the-service-link"
     )
 }

--- a/app/views/ConfirmationPageView.scala.html
+++ b/app/views/ConfirmationPageView.scala.html
@@ -88,7 +88,7 @@
     @p(
         classes="govuk-body",
         id=Some("improve-the-service-body"),
-        content = Html(messages(s"cf.historic.document.request.confirmation.body-text.help"))
+        content = Html(messages("cf.historic.document.request.confirmation.body-text.help"))
     )
 
     @newTabLink(

--- a/app/views/components/newTabLink.scala.html
+++ b/app/views/components/newTabLink.scala.html
@@ -43,5 +43,5 @@
         )
     )
 
-    @postLinkMessage.map(messages(_))@period
+    @postLinkMessage.map(messages(_))
 </p>

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -132,6 +132,10 @@ cf.historic.document.request.confirmation.body-text2.C79Certificate=Byddwch yn g
 cf.historic.document.request.confirmation.body-text2.PostponedVATStatement=Byddwch yn gallu lawrlwytho’ch datganiadau o’r dudalen datganiadau TAW mewnforio ohiriedig.
 cf.historic.document.request.confirmation.body-text2.SecurityStatement=Byddwch yn gallu lawrlwytho’ch datganiadau o’r dudalen ‘Hysbysiad o ddatganiadau addasu’.
 
+cf.historic.document.request.confirmation.subheader-text.help=Help us imporve the service (in thick North Walian accent)
+cf.historic.document.request.confirmation.body-text.help=Do you have an EU EORI number? We're carrying out user research to help improve our services. (in thick North Walian accent)
+cf.historic.document.request.confirmation.link.help=Sign up to take part in user research (in thick North Walian accent) (opens in new tab)
+
 #HistoricDataRequestPageView
 cf.historic.document.request.form.error.date-too-far-in-past=Gallwch ond gofyn am ddatganiadau o ar ôl blwyddyn dreth {0} i {1}.
 cf.historic.document.request.form.error.to-date-must-be-later-than-from-date=Mae’n rhaid i’r dyddiad ‘hyd at’ fod ar neu ar ôl y dyddiad ‘o’

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -133,7 +133,7 @@ cf.historic.document.request.confirmation.body-text2.PostponedVATStatement=Byddw
 cf.historic.document.request.confirmation.body-text2.SecurityStatement=Byddwch yn gallu lawrlwytho’ch datganiadau o’r dudalen ‘Hysbysiad o ddatganiadau addasu’.
 
 cf.historic.document.request.confirmation.subheader-text.help=Helpu ni i wella’r gwasanaeth hwn
-cf.historic.document.request.confirmation.body-text.help=A oes gennych rif EORI yn yr UE? Rydym yn cynnal ymchwil defnyddwyr i helpu i wella ein gwasanaethau
+cf.historic.document.request.confirmation.body-text.help=A oes gennych rif EORI yn yr UE? Rydym yn cynnal ymchwil defnyddwyr i helpu i wella ein gwasanaethau.
 cf.historic.document.request.confirmation.link.help=Cofrestrwch i gymryd rhan mewn ymchwil defnyddwyr (yn agor tab newydd)
 
 #HistoricDataRequestPageView

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -132,9 +132,9 @@ cf.historic.document.request.confirmation.body-text2.C79Certificate=Byddwch yn g
 cf.historic.document.request.confirmation.body-text2.PostponedVATStatement=Byddwch yn gallu lawrlwytho’ch datganiadau o’r dudalen datganiadau TAW mewnforio ohiriedig.
 cf.historic.document.request.confirmation.body-text2.SecurityStatement=Byddwch yn gallu lawrlwytho’ch datganiadau o’r dudalen ‘Hysbysiad o ddatganiadau addasu’.
 
-cf.historic.document.request.confirmation.subheader-text.help=Help us imporve the service (in thick North Walian accent)
-cf.historic.document.request.confirmation.body-text.help=Do you have an EU EORI number? We're carrying out user research to help improve our services. (in thick North Walian accent)
-cf.historic.document.request.confirmation.link.help=Sign up to take part in user research (in thick North Walian accent) (opens in new tab)
+cf.historic.document.request.confirmation.subheader-text.help=Helpu ni i wella’r gwasanaeth hwn
+cf.historic.document.request.confirmation.body-text.help=A oes gennych rif EORI yn yr UE? Rydym yn cynnal ymchwil defnyddwyr i helpu i wella ein gwasanaethau
+cf.historic.document.request.confirmation.link.help=Cofrestrwch i gymryd rhan mewn ymchwil defnyddwyr (yn agor tab newydd)
 
 #HistoricDataRequestPageView
 cf.historic.document.request.form.error.date-too-far-in-past=Gallwch ond gofyn am ddatganiadau o ar ôl blwyddyn dreth {0} i {1}.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -132,8 +132,8 @@ cf.historic.document.request.confirmation.body-text2.C79Certificate=You''ll be a
 cf.historic.document.request.confirmation.body-text2.PostponedVATStatement=You''ll be able to download your statements from the postponed import VAT statements page.
 cf.historic.document.request.confirmation.body-text2.SecurityStatement=You''ll be able to download your statements from the notification of adjustment statements page.
 
-cf.historic.document.request.confirmation.subheader-text.help=Help us imporve the service
-cf.historic.document.request.confirmation.body-text.help=Do you have an EU EORI number? We're carrying out user research to help improve our services.
+cf.historic.document.request.confirmation.subheader-text.help=Help us improve the service
+cf.historic.document.request.confirmation.body-text.help=Do you have an EU EORI number? We''re carrying out user research to help improve our services.
 cf.historic.document.request.confirmation.link.help=Sign up to take part in user research (opens in new tab)
 
 #HistoricDataRequestPageView

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -132,6 +132,10 @@ cf.historic.document.request.confirmation.body-text2.C79Certificate=You''ll be a
 cf.historic.document.request.confirmation.body-text2.PostponedVATStatement=You''ll be able to download your statements from the postponed import VAT statements page.
 cf.historic.document.request.confirmation.body-text2.SecurityStatement=You''ll be able to download your statements from the notification of adjustment statements page.
 
+cf.historic.document.request.confirmation.subheader-text.help=Help us imporve the service
+cf.historic.document.request.confirmation.body-text.help=Do you have an EU EORI number? We're carrying out user research to help improve our services.
+cf.historic.document.request.confirmation.link.help=Sign up to take part in user research (opens in new tab)
+
 #HistoricDataRequestPageView
 cf.historic.document.request.form.error.date-too-far-in-past=You can only request statements from after the {0} to {1} tax year.
 cf.historic.document.request.form.error.to-date-must-be-later-than-from-date=The to date must be on or after the from date

--- a/test/views/ConfirmationPageViewSpec.scala
+++ b/test/views/ConfirmationPageViewSpec.scala
@@ -88,7 +88,7 @@ class ConfirmationPageViewSpec extends SpecBase {
         )
       }
 
-      "Page must contain correct research headder link" in new Setup {
+      "Page must contain correct research header link" in new Setup {
         view.getElementsByClass("improve-the-service-link").text() mustBe messages(
           "cf.historic.document.request.confirmation.link.help"
         )

--- a/test/views/ConfirmationPageViewSpec.scala
+++ b/test/views/ConfirmationPageViewSpec.scala
@@ -75,18 +75,21 @@ class ConfirmationPageViewSpec extends SpecBase {
           "cf.historic.document.request.confirmation.back-to-dashboard.link-text"
         )
       }
-      "Page must contain correct research headder text" in new Setup {
-        view.getElementById("email-confirmation-subheader-help").text() mustBe messages(
+
+      "Page must contain correct research header text" in new Setup {
+        view.getElementById("improve-the-service-heading").text() mustBe messages(
           "cf.historic.document.request.confirmation.subheader-text.help"
         )
       }
+
       "Page must contain correct research description text" in new Setup {
-        view.getElementById("email-confirmation-body-help").text() mustBe messages(
+        view.getElementById("improve-the-service-body").text() mustBe messages(
           "cf.historic.document.request.confirmation.body-text.help"
         )
       }
+
       "Page must contain correct research headder link" in new Setup {
-        view.getElementsByClass("hmrc-user-research-banner-link").text() mustBe messages(
+        view.getElementsByClass("improve-the-service-link").text() mustBe messages(
           "cf.historic.document.request.confirmation.link.help"
         )
       }

--- a/test/views/ConfirmationPageViewSpec.scala
+++ b/test/views/ConfirmationPageViewSpec.scala
@@ -75,6 +75,21 @@ class ConfirmationPageViewSpec extends SpecBase {
           "cf.historic.document.request.confirmation.back-to-dashboard.link-text"
         )
       }
+      "Page must contain correct research headder text" in new Setup {
+        view.getElementById("email-confirmation-subheader-help").text() mustBe messages(
+          "cf.historic.document.request.confirmation.subheader-text.help"
+        )
+      }
+      "Page must contain correct research description text" in new Setup {
+        view.getElementById("email-confirmation-body-help").text() mustBe messages(
+          "cf.historic.document.request.confirmation.body-text.help"
+        )
+      }
+      "Page must contain correct research headder link" in new Setup {
+        view.getElementsByClass("hmrc-user-research-banner-link").text() mustBe messages(
+          "cf.historic.document.request.confirmation.link.help"
+        )
+      }
     }
 
     "display Welsh toggle" in new Setup {

--- a/test/views/components/NewTabLinkSpec.scala
+++ b/test/views/components/NewTabLinkSpec.scala
@@ -36,10 +36,10 @@ class NewTabLinkSpec extends SpecBase {
           newTabLinkComponent(linkMessage, href, Some(preLinkMessage), Some(postLinkMessage), classes)
 
         elementByParagraph(component).text() mustBe
-          s"$preLinkMessage$emptyStringWithSpace$linkMessage$emptyStringWithSpace$postLinkMessage$period"
+          s"$preLinkMessage$emptyStringWithSpace$linkMessage$emptyStringWithSpace$postLinkMessage"
 
         elementByClasses(component, classes).get(0).text() mustBe
-          s"$preLinkMessage$emptyStringWithSpace$linkMessage$emptyStringWithSpace$postLinkMessage$period"
+          s"$preLinkMessage$emptyStringWithSpace$linkMessage$emptyStringWithSpace$postLinkMessage"
 
         shouldContainTheMessage(component, preLinkMessage)
         shouldContainTheMessage(component, postLinkMessage)
@@ -49,10 +49,10 @@ class NewTabLinkSpec extends SpecBase {
         val component: Document =
           newTabLinkComponent(linkMessage = linkMessage, href = href, postLinkMessage = Some(postLinkMessage))
 
-        elementByParagraph(component).text() mustBe s"$linkMessage$emptyStringWithSpace$postLinkMessage$period"
+        elementByParagraph(component).text() mustBe s"$linkMessage$emptyStringWithSpace$postLinkMessage"
 
         elementByClasses(component, defaultClasses).get(0).text() mustBe
-          s"$linkMessage$emptyStringWithSpace$postLinkMessage$period"
+          s"$linkMessage$emptyStringWithSpace$postLinkMessage"
 
         shouldNotContainTheMessage(component, preLinkMessage)
         shouldContainTheMessage(component, postLinkMessage)
@@ -63,10 +63,10 @@ class NewTabLinkSpec extends SpecBase {
           newTabLinkComponent(linkMessage = linkMessage, href = href, preLinkMessage = Some(preLinkMessage))
 
         elementByParagraph(component)
-          .text() mustBe s"$preLinkMessage$emptyStringWithSpace$linkMessage$emptyStringWithSpace$period"
+          .text() mustBe s"$preLinkMessage$emptyStringWithSpace$linkMessage"
 
         elementByClasses(component, defaultClasses).get(0).text() mustBe
-          s"$preLinkMessage$emptyStringWithSpace$linkMessage$emptyStringWithSpace$period"
+          s"$preLinkMessage$emptyStringWithSpace$linkMessage"
 
         shouldContainTheMessage(component, preLinkMessage)
         shouldNotContainTheMessage(component, postLinkMessage)


### PR DESCRIPTION
This work is being carried out against this ticket
https://jira.tools.tax.service.gov.uk/browse/MMCA-5338

The aim is to add points feedback into the request confirmation flow

This change should be visible in 
Request older duty deferment statements [confirmation page](https://customs-financials-prototype.herokuapp.com/version33/DutyDeferment/request-older-duty-deferment_confirmation)

Request older import VAT certificates (C79) [confirmation page](https://customs-financials-prototype.herokuapp.com/version33/ImportVAT/request-older-import-vat_confirmation)

Request older import VAT statements [confirmation page](https://customs-financials-prototype.herokuapp.com/version33/PostponedVAT/request-older-postponed-vat_confirmation)

Request older Notification of adjustment statements [confirmation page](https://customs-financials-prototype.herokuapp.com/version33/NofA/request-older-adjustment-statements_confirmation)
