### PR TITLE
MMCA-5358: Amend screen from browser back for customs-historic-statement-frontend

### DIFF
--- a/app/views/SessionExpiredView.scala.html
+++ b/app/views/SessionExpiredView.scala.html
@@ -28,11 +28,13 @@ layout: Layout,
 
 @()(implicit request: Request[_], messages: Messages, appConfig: FrontendAppConfig)
 
- @layout(Some(titleNoForm("session_expired.title")), backLinkUrl = Some(appConfig.financialsHomepage)) {
+  @layout(Some(titleNoForm("session_expired.title")), backLinkUrl = Some(appConfig.financialsHomepage)) {
 
   @h1(messages("session_expired.heading"))
 
   @p(Html(messages("session_expired.guidance")))
 
   @link2(button("session_expired.action"), url=appConfig.financialsHomepage)
+
+  </br>
  }

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,6 @@ lazy val root = (project in file("."))
     retrieveManaged := true,
     update / evictionWarningOptions :=
       EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
-    resolvers += Resolver.jcenterRepo,
     Concat.groups := Seq(
       "javascripts/customshistoricstatementfrontend-app.js" ->
         group(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "9.11.0"
+  val bootstrapVersion = "9.13.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.7")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
 addSbtPlugin("com.github.sbt" % "sbt-concat" % "1.0.0")


### PR DESCRIPTION
If a user were to use the browser back button at the confirmation stage they are shown a screen that says 'for security reasons, this service has been reset'. 

The 'is this page not working properly' hyperlink is next to the 'start again' button, instead of below it. 

