### PR TITLE
[MMCA-5408] - Filter 404 code for EORI history call and add warn level

### DIFF
--- a/test/utils/WireMockSupportProvider.scala
+++ b/test/utils/WireMockSupportProvider.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import com.github.tomakehurst.wiremock.client.WireMock.{getRequestedFor, urlPathMatching}
+import org.scalatest.Suite
+import play.api.Configuration
+import uk.gov.hmrc.http.test.WireMockSupport
+
+trait WireMockSupportProvider extends WireMockSupport {
+
+  this: Suite =>
+
+  def config: Configuration
+
+  protected def verifyEndPointUrlHit(urlToVerify: String): Unit = wireMockServer.verify(
+    getRequestedFor(
+      urlPathMatching(urlToVerify)
+    )
+  )
+}

--- a/test/views/components/NewTabLinkSpec.scala
+++ b/test/views/components/NewTabLinkSpec.scala
@@ -21,7 +21,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.scalatest.Assertion
-import utils.Utils.{emptyStringWithSpace, period}
+import utils.Utils.emptyStringWithSpace
 import utils.TestData.{classes, defaultClasses, href, linkMessage, postLinkMessage, preLinkMessage}
 import views.html.components.newTabLink
 


### PR DESCRIPTION
Description - Filter 404 response code (from customs data store) for EORI history API call 

Below has been done as part of this PR

- [x] add WireMock support
- [x] update existing tests to use WireMock
- [x] add tests
- [x] add relevant code to filter 404